### PR TITLE
chore: harden repository governance

### DIFF
--- a/.github/ISSUE_TEMPLATE/evidence_governance_task.yml
+++ b/.github/ISSUE_TEMPLATE/evidence_governance_task.yml
@@ -1,0 +1,76 @@
+name: Evidence or governance task
+description: Propose evidence, dependency, dossier, contract, rights, or decision-record work that does not change governing physics.
+title: "[Evidence/governance] "
+labels: ["scientific-review", "evidence", "no-physics-change"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Fixed change declaration
+
+        `NO_GOVERNING_PHYSICS_CHANGE`
+
+        Use this form only when the task will not change governing physics or scientific configuration.
+  - type: input
+    id: objective
+    attributes:
+      label: Objective
+      description: State the single outcome this governed task should achieve.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence_or_governance_need
+    attributes:
+      label: Evidence, source, or governance need
+      description: Identify the evidence gap, dependency review, source dossier, contract, rights question, or decision need.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Identify the records, interfaces, sources, or repository areas that are in scope.
+    validations:
+      required: true
+  - type: textarea
+    id: required_outputs
+    attributes:
+      label: Required outputs
+      description: List the concrete documents, inventories, manifests, contracts, or decision records to produce.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance_gates
+    attributes:
+      label: Acceptance gates
+      description: Give the objective checks and review conditions required for acceptance.
+    validations:
+      required: true
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals
+      description: State what this task must not change or attempt.
+    validations:
+      required: true
+  - type: textarea
+    id: dependencies_and_blockers
+    attributes:
+      label: Dependencies and blockers
+      description: Identify prerequisite issues, decisions, locked dependencies, missing authority, or write N/A.
+    validations:
+      required: true
+  - type: textarea
+    id: quantity_and_rights_semantics
+    attributes:
+      label: Quantity, evidence, and rights semantics
+      description: Record applicable units, bases, pressure nodes, calibration roles, protected comparisons, uncertainty, and rights. Write N/A only for categories that genuinely do not apply.
+    validations:
+      required: true
+  - type: checkboxes
+    id: declaration_confirmation
+    attributes:
+      label: Declaration confirmation
+      options:
+        - label: I confirm this task is `NO_GOVERNING_PHYSICS_CHANGE` and does not authorize a scientific-configuration change.
+          required: true

--- a/.github/ISSUE_TEMPLATE/scientific_change.yml
+++ b/.github/ISSUE_TEMPLATE/scientific_change.yml
@@ -8,20 +8,65 @@ body:
     attributes:
       label: Change declaration
       options:
+        - NO_GOVERNING_PHYSICS_CHANGE
         - SOURCE_SCENARIO_CHANGE_ONLY
         - NUMERICAL_METHOD_CHANGE
         - GOVERNING_PHYSICS_CHANGE
     validations:
       required: true
   - type: textarea
-    id: rationale
+    id: objective
     attributes:
-      label: Named residual, evidence need, or engineering decision
+      label: Objective
+      description: State the single scientific or engineering outcome.
     validations:
       required: true
   - type: textarea
-    id: evidence
+    id: decision_need
     attributes:
-      label: Sources, calibration data, protected comparisons, uncertainty, and rights
+      label: Named residual, evidence need, or engineering decision
+      description: Name the specific residual, evidence gap, or decision that justifies the proposed change.
+    validations:
+      required: true
+  - type: textarea
+    id: affected_scientific_content
+    attributes:
+      label: Affected equations, source, configuration, or outputs
+      description: Identify exact equations, source files, configurations, interfaces, quantities, or outputs that may change.
+    validations:
+      required: true
+  - type: textarea
+    id: evidence_contract
+    attributes:
+      label: Evidence, calibration data, protected comparisons, uncertainty, and rights
+      description: Separate prescribed, calibrated, predicted, and protected quantities; include sources, units, bases, pressure nodes, uncertainty, and rights.
+    validations:
+      required: true
+  - type: textarea
+    id: verification_validation
+    attributes:
+      label: Required verification and validation
+      description: List analytical, numerical, regression, source-linked comparison, or other required gates without overstating physical validation.
+    validations:
+      required: true
+  - type: textarea
+    id: claim_ceiling
+    attributes:
+      label: Claim-ceiling impact
+      description: State the current ceiling and whether the proposed work preserves, narrows, or could justify a separately reviewed change to it.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance_gates
+    attributes:
+      label: Acceptance gates
+      description: Give measurable conditions required before the change can be accepted.
+    validations:
+      required: true
+  - type: textarea
+    id: non_goals_dependencies
+    attributes:
+      label: Non-goals and dependencies
+      description: State excluded work, prerequisite issues, locked dependencies, and blockers.
     validations:
       required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,21 +1,52 @@
+## Linked issue
+
+<!-- Use "Closes #..." when merge should close the principal governed issue. -->
+
+Closes #
+
 ## Summary
 
-## Change declaration
+## Change declaration — select exactly one
 
 - [ ] `NO_GOVERNING_PHYSICS_CHANGE`
 - [ ] `SOURCE_SCENARIO_CHANGE_ONLY`
 - [ ] `NUMERICAL_METHOD_CHANGE`
 - [ ] `GOVERNING_PHYSICS_CHANGE`
 
-## Evidence and claim impact
+## Files and interfaces changed
 
-## Validation
+## Puckworks dependency
+
+- Old SHA: N/A
+- New SHA: N/A
+- Reason for N/A or dependency change:
+
+## Quantity roles
+
+- Prescribed:
+- Calibrated:
+- Predicted:
+- Protected comparisons:
+
+## Evidence, uncertainty, rights, and claim impact
+
+## Local OpenFOAM execution and artifacts
+
+- Execution count: 0
+- External artifact locations and identities, or explicit N/A:
+
+## Generated/runtime products excluded from Git
+
+## Validation performed
 
 - [ ] Source manifest verification
 - [ ] Static validation
 - [ ] Python tests
+- [ ] No-physics contract, where applicable
 - [ ] Shell and JSON checks
 - [ ] Boundary and secret scans
 - [ ] No generated OpenFOAM products
+
+## Remaining limitations and reviewer questions
 
 Physical validation is not established by passing these checks.

--- a/.github/workflows/source-integrity.yml
+++ b/.github/workflows/source-integrity.yml
@@ -2,6 +2,10 @@ name: Source integrity
 
 on:
   push:
+    branches:
+      - main
+    tags:
+      - "v*"
   pull_request:
 
 permissions:

--- a/.github/workflows/static-validation.yml
+++ b/.github/workflows/static-validation.yml
@@ -2,6 +2,10 @@ name: Static validation
 
 on:
   push:
+    branches:
+      - main
+    tags:
+      - "v*"
   pull_request:
 
 permissions:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,22 @@
 
 Contributions are welcome through focused issues and pull requests.
 
+## Choose the governed issue form
+
+Use the **Evidence or governance task** form for evidence inventories,
+dependency reviews, source dossiers, calibration or validation contracts,
+rights reviews, scientific decision records, and similar tasks that declare
+`NO_GOVERNING_PHYSICS_CHANGE`.
+
+Use the **Scientific change proposal** form for source-scenario,
+numerical-method, or governing-physics changes. It may also record a
+no-physics change when a scientific-change review is specifically appropriate.
+
+One governed issue should normally map to one principal pull request. Complete
+each form field with the information it asks for; do not paste the same task
+description into multiple fields. Every pull request must identify its
+principal issue and select exactly one change declaration.
+
 Before proposing a change:
 
 1. Read `docs/ONBOARDING.md`, `docs/CLAIM_CEILING.md`, and the controlling strategy.
@@ -10,6 +26,13 @@ Before proposing a change:
 4. Run the inexpensive validation suite.
 5. Do not commit generated OpenFOAM products or private/local metadata.
 
+Generated fields, meshes, processor directories, executables, runtime logs,
+uncleaned runs, and other OpenFOAM products remain outside Git. Record their
+external identities when a governed task produces them.
+
 Scientific changes require a reviewed rationale, affected equations/configuration, tests, provenance, and claim-impact assessment. Passing tests do not establish physical validation.
+
+R1 implementation may not begin until its source/evidence and
+calibration/protected-comparison contracts have been reviewed and accepted.
 
 Contributions are provided under the repository’s applicable licenses.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -2,6 +2,22 @@
 
 Read `README.md`, `docs/PROJECT_STATE.md`, `docs/CLAIM_CEILING.md`, the controlling strategy, and `CONTRIBUTING.md`.
 
+## Governed issues and pull requests
+
+Choose the **Evidence or governance task** issue form for no-physics evidence
+inventories, dependency reviews, source dossiers, calibration or validation
+contracts, rights reviews, and scientific decision records. Choose the
+**Scientific change proposal** form for scenario, numerical-method, or
+governing-physics changes.
+
+One governed issue should normally lead to one principal pull request. Do not
+duplicate the same material across issue-form fields. Every pull request must
+identify its issue and select exactly one change declaration.
+
+Generated OpenFOAM fields, meshes, processor directories, executables, logs,
+and uncleaned runs remain outside Git. R1 implementation may not begin before
+its evidence and protected-comparison contracts are accepted.
+
 ## Inexpensive checks
 
 ```bash


### PR DESCRIPTION
## Governed task

REPO-GOV-001 (no existing GitHub issue is modified or closed by this PR).

## Change declaration

`NO_GOVERNING_PHYSICS_CHANGE`

## Summary

The existing scientific issue form compressed distinct governance questions into two large text areas and did not offer the full four-value declaration vocabulary. Evidence-only work therefore lacked a focused form, while feature-branch pushes duplicated pull-request CI runs.

This PR:

- adds an evidence/governance issue form with the fixed `NO_GOVERNING_PHYSICS_CHANGE` declaration and required evidence-semantic fields;
- expands the scientific-change form into separate objective, decision-need, affected-content, evidence-contract, verification/validation, claim-impact, acceptance, and dependency fields;
- expands the pull-request template to capture the principal issue, exactly one declaration, interfaces, dependency SHA, quantity roles, evidence/rights/uncertainty, execution artifacts, exclusions, validation, limitations, and reviewer questions;
- documents form selection, one governed issue to one principal PR, generated-product exclusions, and the R1 contract prerequisite;
- limits workflow push triggers to `main` and `v*` tags while retaining all pull-request checks, workflow names, job IDs, read-only permissions, checkout v7, and validation steps.

## Validation

- `git diff --check`: PASS
- Public source manifest: 106/106 PASS; aggregate `ad6f9b84e69b6178d77f867a085198908dcda4afe2360ec840824faadc793267`
- Scientific inputs: 19/19 PASS; aggregate `d70399a76b0023d93985d76c1c83a9a42b7148b3d71d16d1b5f88275be1ebe7a`
- Static validation: 32/32 PASS
- Python tests: 41/41 PASS
- No-physics contract: 28/28 PASS; `governing_physics_change=false`
- Scientific configuration change: false
- Shell syntax: PASS
- JSON parsing: PASS
- YAML/CFF parsing: PASS (8 files)
- Markdown local links: PASS
- Private-path and secret scan: PASS
- Generated OpenFOAM product scan: PASS
- OpenFOAM execution count: 0

No Puckworks lock, dependency content, solver source, scientific input, OpenFOAM dictionary, calibration value, numerical scheme, or acceptance threshold changes.

Passing numerical checks does not establish physical validation. Physical validation remains `NOT_ESTABLISHED`.
