### PR TITLE
WP-0.2G: reconcile post-release state

### DIFF
--- a/PACKAGE_QA_STATUS.json
+++ b/PACKAGE_QA_STATUS.json
@@ -5,7 +5,7 @@
   "release_role": "NO_GOVERNING_PHYSICS_RELEASE_FINALIZATION",
   "target": "OpenFOAM Foundation 12",
   "governing_physics_change_after_baseline": false,
-  "release_qualification": "PASS_PENDING_PR_MERGE_AND_POST_MERGE_TAG",
+  "release_qualification": "PASS",
   "scientific_result": {
     "sha256": "75a79e9972176668a8bfdb574ea16cbf39373a9ea11078009bc7b997c2f76859",
     "overall_disposition": "SOURCE_LINKED_MULTIPRESSURE_RECONSTRUCTION_PASS",
@@ -30,5 +30,14 @@
   },
   "executed_scientific_solver_executable_sha256": "39056c46c74c53a254e969d02f989ce720dfb567924a90c2f5f8d3b661469ba0",
   "release_executable_sha256": "5af892d6382cbc47fa2e6b505fccacf7390bb42bc8d7177106620a43fb26c97b",
+  "final_disposition": "SOFTWARE_AND_SOURCE_LINKED_RECONSTRUCTION_RELEASE_PASS",
+  "published_release": {
+    "tag": "v0.2.0",
+    "merge_commit": "6e6b35b0fc6747f805223ce7975a0865835f01f0",
+    "url": "https://github.com/trbrewer/espresso-whole-pull/releases/tag/v0.2.0",
+    "asset_count": 10,
+    "final_terminal_manifest_sha256": "fe4c64af5cbb859793bdc0170ef1674b7584effce0f26a2b40836f3d247d3550"
+  },
+  "next_scientific_milestone": "WP-0.3A_INDEPENDENT_HOLDOUT_AND_MECHANISM_DISCRIMINATION_CONTRACT",
   "claim_ceiling": "Software and source-linked reconstruction release only; independent physical validation and universal transfer remain NOT_ESTABLISHED."
 }

--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ baseline and retains its historical no-governing-physics release contract.
 Version 0.2.0 is a software and source-linked reconstruction release, not a
 physical-validation release.
 
+The published release and bounded assets are available at
+[v0.2.0](https://github.com/trbrewer/espresso-whole-pull/releases/tag/v0.2.0).
+The next scientific milestone is WP-0.3A independent holdout and
+mechanism-discrimination contracting; no additional mechanism is authorized.
+
 ## License
 
 The solver and repository code are licensed under GPL-3.0-or-later. See `LICENSE`, `NOTICE.md`, `THIRD_PARTY_NOTICES.md`, and `docs/LICENSING.md`. This licensing audit is informational and not legal advice.

--- a/SOURCE_PACKAGE_MANIFEST.json
+++ b/SOURCE_PACKAGE_MANIFEST.json
@@ -24,12 +24,12 @@
     "Make/linux*/ build products",
     "deterministically generated case dictionaries and case/0 fields"
   ],
-  "file_count": 131,
-  "total_uncompressed_bytes_excluding_manifest": 1258236,
-  "aggregate_source_sha256": "4182c59cfef51251903331377a32951f2384806105ae8ee5d5c60c55172aca87",
-  "aggregate_sha256": "4182c59cfef51251903331377a32951f2384806105ae8ee5d5c60c55172aca87",
-  "strategy_source_path": "docs/source_strategy/espresso_puck_modeling_and_simulation_strategy_v1_3.md",
-  "strategy_source_sha256": "beb3922bf5b246a17760eb0e445d1d26791bcf8d03b38dea5149998d985bd7bc",
+  "file_count": 132,
+  "total_uncompressed_bytes_excluding_manifest": 1264005,
+  "aggregate_source_sha256": "90fd3023e9b97b1b42b0e1cfa25c7e76858ce40a00b0fec69881ab8bfeced651",
+  "aggregate_sha256": "90fd3023e9b97b1b42b0e1cfa25c7e76858ce40a00b0fec69881ab8bfeced651",
+  "strategy_source_path": "docs/source_strategy/espresso_puck_modeling_and_simulation_strategy_v1_4.md",
+  "strategy_source_sha256": "3e3b96b39f81c5e2df5c2dbe42103a4a5a58f928b9e5409bbcaeb861761377b9",
   "files": {
     "Allclean": {
       "sha256": "0bcb5c9a56e6afd73ea47ab7748eab95466d809cda6c66e93f0225d4ff59341e",
@@ -57,8 +57,8 @@
       "git_mode": "100644"
     },
     "README.md": {
-      "sha256": "adc13b51b4cd8e3a8bc1466d2f27feaf68dff512e942b117e31bca3bcc38f8fe",
-      "bytes": 3338,
+      "sha256": "2d75b385dd963e4c68bb683ca31659c68c24242bb1d13291ca7742e86ab63f3b",
+      "bytes": 3618,
       "git_mode": "100644"
     },
     "VERSION": {
@@ -442,8 +442,8 @@
       "git_mode": "100644"
     },
     "docs/QA_STATUS.md": {
-      "sha256": "6ad4fcadd92e45f3974811fc60f37e649a4fe41c32ca299d981f1bd89d8e6b4d",
-      "bytes": 3977,
+      "sha256": "c22334e9f9756c618428f421c6c7f231c181b0f2e9e5e23d1d6143bdc8775a7c",
+      "bytes": 4185,
       "git_mode": "100644"
     },
     "docs/RUNBOOK_AND_TROUBLESHOOTING.md": {
@@ -459,6 +459,11 @@
     "docs/source_strategy/espresso_puck_modeling_and_simulation_strategy_v1_3.md": {
       "sha256": "beb3922bf5b246a17760eb0e445d1d26791bcf8d03b38dea5149998d985bd7bc",
       "bytes": 3680,
+      "git_mode": "100644"
+    },
+    "docs/source_strategy/espresso_puck_modeling_and_simulation_strategy_v1_4.md": {
+      "sha256": "3e3b96b39f81c5e2df5c2dbe42103a4a5a58f928b9e5409bbcaeb861761377b9",
+      "bytes": 2160,
       "git_mode": "100644"
     },
     "scripts/analyze_r1.py": {
@@ -502,7 +507,7 @@
       "git_mode": "100755"
     },
     "scripts/generate_source_manifest.py": {
-      "sha256": "2107f4f660e5821e7a455a9d97c6901851b6680c204bd0dbd0512327d9fb7047",
+      "sha256": "3a890557d9b8c4884bd47257a13c4f049b82441f0220377a9ce21c02dab5a138",
       "bytes": 8508,
       "git_mode": "100755"
     },
@@ -587,8 +592,8 @@
       "git_mode": "100755"
     },
     "scripts/verify_release_finalization.py": {
-      "sha256": "05a5e647cda4cdb7f1ec97ba66912abc74c42a3c45a15f975850ac486405c3f0",
-      "bytes": 5891,
+      "sha256": "e2fd389455a15641247dbcc7ee279c0502650694cebe4b5cb0d96cdb2fc1d012",
+      "bytes": 7886,
       "git_mode": "100755"
     },
     "scripts/verify_source_manifest.py": {
@@ -662,8 +667,8 @@
       "git_mode": "100644"
     },
     "tests/test_change_contract.py": {
-      "sha256": "ec8f656abc1c1938e68e7166a99d2b1756e24e655408247ef02d00b0611767b5",
-      "bytes": 6372,
+      "sha256": "08968615389dda13fe4adf4cc9c3fcfc237b00444fcf14cc24e11d3ba8432299",
+      "bytes": 7498,
       "git_mode": "100644"
     },
     "tests/test_r1_analysis.py": {

--- a/docs/DEVELOPMENT_HISTORY.md
+++ b/docs/DEVELOPMENT_HISTORY.md
@@ -14,5 +14,8 @@
 - v0.2.0 / WP-0.2F: no-governing-physics release finalization of the accepted
   WP-0.2A source-linked multipressure reconstruction. The release build is
   distinct from the immutable executable that produced the scientific traces.
+- WP-0.2G: post-release provenance reconciliation records the published tag,
+  assets, final terminal manifest, and next WP-0.3A evidence-contract task
+  without changing the release or scientific records.
 
 Exact archival runs and bytes remain offline. Public history begins with the sanitized derivative and must not be described as byte-identical to archival v0.1.4.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -1,9 +1,10 @@
 # Project State
 
-- Current release candidate: `0.2.0`, milestone `WP-0.2F`
+- Current released version: `v0.2.0`
 - Public baseline: `v0.1.4-public.1`, immutable sanitized R0 derivative
 - Archival baseline: WP-0.1H v0.1.4, `FROZEN / QUALIFIED`
-- Public source verification: 131/131 PASS
+- Public source verification: 132/132 PASS (current main)
+- Published v0.2.0 source verification: 131/131 PASS
 - Scientific inputs: 19/19 byte-identical to archival baseline
 - Frozen R0 scientific-configuration change: false
 - Governed R1 scenario present: true
@@ -11,7 +12,8 @@
 - Governing-physics change in WP01R-005: false
 - Governing-physics change in WP02-001: true
 - WP02 optional closure added: true
-- Release qualification: `FINALIZATION_IN_PROGRESS`
+- Release qualification: `PASS`
+- Release disposition: `SOFTWARE_AND_SOURCE_LINKED_RECONSTRUCTION_RELEASE_PASS`
 - R0 claim ceiling: `NUMERICALLY_QUALIFIED_CALIBRATION_BASELINE`
 - Physical validation: `NOT_ESTABLISHED`
 - OpenFOAM target: Foundation 12
@@ -27,12 +29,13 @@ passed; the protected flow-shape gate failed and exactly reproduced the
 preliminary PR #16 disposition. R0 remains frozen and unchanged. Physical
 validation is `NOT_ESTABLISHED`.
 
-WP01R-006 selected the Waszkiewicz saturated dissolution-indexed
+WP-0.2F successfully published v0.2.0. WP01R-006 selected the Waszkiewicz saturated dissolution-indexed
 effective-permeability branch for WP-0.2A. WP02-001 implemented and tested it,
 merged through PR #20, and is scientifically closed. WP-0.2F release
-finalization is the immediate task. Independent physical validation has not
-started. Machine/headspace coupling remains a later runner-up subject to
-holdout evidence and mechanism discrimination.
+finalization is complete. WP-0.3A independent holdout and
+mechanism-discrimination contracting is next. Independent physical validation
+has not started. Machine/headspace coupling remains a later runner-up subject
+to holdout evidence and mechanism discrimination.
 
 WP02-001 added the optional saturated dissolution-indexed effective-permeability
 closure. Its corrected uniform fixture, disabled R0 regression, and disabled

--- a/docs/QA_STATUS.md
+++ b/docs/QA_STATUS.md
@@ -2,7 +2,12 @@
 
 **Active role:** WP-0.2F no-physics release finalization
 
-**Release qualification:** candidate gates pending
+**Release qualification:** PASS
+
+**Release disposition:** SOFTWARE_AND_SOURCE_LINKED_RECONSTRUCTION_RELEASE_PASS
+
+**Release gates:** 119/119 Python tests, 34/34 active static gates, 131/131
+source-manifest entries, and a passing OpenFOAM Foundation 12 build.
 
 **Historical baseline:** v0.1.4-public.1 remains immutable and independently
 checked by the baseline-integrity verifier.

--- a/docs/source_strategy/espresso_puck_modeling_and_simulation_strategy_v1_4.md
+++ b/docs/source_strategy/espresso_puck_modeling_and_simulation_strategy_v1_4.md
@@ -1,0 +1,51 @@
+# Espresso Puck Modeling and Simulation Strategy
+
+**Strategy version:** 1.4  
+**Date:** 29 July 2026  
+**Status:** Controlling post-v0.2.0 strategy  
+**Supersedes:** Strategy v1.3 without rewriting it  
+**Current released version:** v0.2.0  
+**Physical validation:** `NOT_ESTABLISHED`
+
+## Released state
+
+WP-0.2F completed and published v0.2.0 at merge commit
+`6e6b35b0fc6747f805223ce7975a0865835f01f0`. The release is classified
+`SOFTWARE_AND_SOURCE_LINKED_RECONSTRUCTION_RELEASE_PASS`.
+
+The immutable WP02-001 result remains
+`SOURCE_LINKED_MULTIPRESSURE_RECONSTRUCTION_PASS`. It records a passing
+source-linked 9-bar reconstruction and a passing predeclared 8-bar
+no-retuning same-campaign comparison. The 8-bar result is not independent
+validation. The release does not establish full deformation, cross-rig
+transfer, early wetting, channeling, fines, chemistry, taste, or a universal
+permeability law.
+
+The historical scientific executable and release executable retain distinct
+roles. The release changed no scientific result, trace, configuration,
+closure, selector, threshold, or score.
+
+## Next program
+
+No new mechanism is authorized. The next milestone is WP-0.3A: qualify
+independent holdout evidence and freeze a mechanism-discrimination contract
+before any score-bearing execution.
+
+WP-0.3A must:
+
+1. perform a fresh moving-upstream Puckworks review before adopting anything
+   newer than the locked historical dependency;
+2. inventory evidence, rights, uncertainty, units, mappings, and validation
+   roles;
+3. require time-resolved pressure and flow plus geometry, timing, preparation,
+   and uncertainty for a hydraulic holdout;
+4. compare only already-frozen R0, constant-R1, and v0.2.0 WP02 branches where
+   scientifically meaningful;
+5. freeze metrics, thresholds, mappings, access procedures, and claim ceiling
+   before any holdout execution;
+6. stop without execution if no qualifying independent hydraulic holdout is
+   available.
+
+Independent holdout validation and mechanism discrimination—not another
+implementation—are the next scientific priority. Development remains
+progressive, evidence-driven, and one mechanism at a time.

--- a/scripts/generate_source_manifest.py
+++ b/scripts/generate_source_manifest.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Dict, Iterable
 
 MANIFEST_NAME = "SOURCE_PACKAGE_MANIFEST.json"
-STRATEGY_RELATIVE = "docs/source_strategy/espresso_puck_modeling_and_simulation_strategy_v1_3.md"
+STRATEGY_RELATIVE = "docs/source_strategy/espresso_puck_modeling_and_simulation_strategy_v1_4.md"
 PUBLIC_METADATA_TOP_LEVEL = {
     ".editorconfig",
     ".gitattributes",

--- a/scripts/verify_release_finalization.py
+++ b/scripts/verify_release_finalization.py
@@ -12,6 +12,9 @@ from pathlib import Path
 DEFAULT_CONTRACT = Path(
     "validation/wp02/WP_0_2F_RELEASE_FINALIZATION_CONTRACT.json"
 )
+POST_RELEASE_RECORD = Path(
+    "validation/release/WP_0_2G_POST_RELEASE_STATE_RECONCILIATION.json"
+)
 
 
 def digest(path: Path) -> str:
@@ -77,6 +80,11 @@ def verify(root: Path, declaration_path: Path | None = None) -> dict:
     paths = changed_paths(root, contract["baseline"]["merge_commit"])
     allowed = set(contract["allowed_changed_paths"])
     prefixes = tuple(contract["allowed_changed_path_prefixes"])
+    post_release_record = None
+    post_release_path = root / POST_RELEASE_RECORD
+    if post_release_path.is_file():
+        post_release_record = json.loads(post_release_path.read_text())
+        allowed.update(post_release_record["allowed_post_release_changed_paths"])
     path_boundary = paths is None or all(
         path in allowed or path.startswith(prefixes) for path in paths
     )
@@ -115,6 +123,39 @@ def verify(root: Path, declaration_path: Path | None = None) -> dict:
         and contract["governed_scientific_solver_reruns_allowed"] is False
         and contract["scientific_score_recalculation_allowed"] is False
         and contract["governing_physics_change_allowed"] is False,
+        "post_release_state_reconciled": post_release_record is None
+        or (
+            post_release_record["classification"]
+            == [
+                "POST_RELEASE_DOCUMENTATION_AND_PROVENANCE_ONLY",
+                "NO_GOVERNING_PHYSICS_CHANGE",
+                "NO_SCIENTIFIC_RESULT_CHANGE",
+            ]
+            and post_release_record["release"]["tag"] == "v0.2.0"
+            and post_release_record["release"]["tag_target"]
+            == "6e6b35b0fc6747f805223ce7975a0865835f01f0"
+            and post_release_record["immutable_identities"][
+                "scientific_result_sha256"
+            ]
+            == immutable["scientific_result_sha256"]
+            and post_release_record[
+                "tagged_tree_contains_prepublication_status_snapshot"
+            ]
+            is True
+            and post_release_record[
+                "final_publication_state_is_bound_by_release_asset_manifest"
+            ]
+            is True
+            and post_release_record["tag_changed"] is False
+            and post_release_record["release_assets_changed"] is False
+            and post_release_record["scientific_records_changed"] is False
+            and post_release_record["protected_accesses_added"] == 0
+            and post_release_record["analyzer_invocations_added"] == 0
+            and post_release_record["governed_solver_executions_added"] == 0
+            and post_release_record["score_recalculations_added"] == 0
+            and post_release_record["fitting_or_retuning"] is False
+            and post_release_record["physical_validation"] == "NOT_ESTABLISHED"
+        ),
         "changed_path_boundary": path_boundary,
     }
     passed = all(checks.values())

--- a/tests/test_change_contract.py
+++ b/tests/test_change_contract.py
@@ -65,6 +65,34 @@ class ChangeContractRoutingTests(unittest.TestCase):
             finally:
                 temporary.cleanup()
 
+    def test_post_release_record_preserves_published_release_boundary(self) -> None:
+        report = verify_release(ROOT)
+        self.assertEqual(report["status"], "PASS")
+        self.assertEqual(
+            report["checks"]["post_release_state_reconciled"]["status"], "PASS"
+        )
+
+    def test_post_release_record_rejects_tag_or_scientific_identity_change(self) -> None:
+        for key_path, replacement in (
+            (("release", "tag_target"), "0" * 40),
+            (
+                ("immutable_identities", "scientific_result_sha256"),
+                "0" * 64,
+            ),
+        ):
+            temporary, root = self.copy_root()
+            try:
+                path = (
+                    root
+                    / "validation/release/WP_0_2G_POST_RELEASE_STATE_RECONCILIATION.json"
+                )
+                value = json.loads(path.read_text())
+                value[key_path[0]][key_path[1]] = replacement
+                path.write_text(json.dumps(value))
+                self.assertEqual(verify_release(root)["status"], "FAIL")
+            finally:
+                temporary.cleanup()
+
     def test_governing_change_fails_with_v0_1_4_active_version(self) -> None:
         temporary, root = self.copy_root()
         try:

--- a/validation/release/WP_0_2G_POST_RELEASE_STATE_RECONCILIATION.json
+++ b/validation/release/WP_0_2G_POST_RELEASE_STATE_RECONCILIATION.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": "espresso.public.wp_0_2g_post_release_state_reconciliation.v1",
+  "task": "WP-0.2G",
+  "classification": [
+    "POST_RELEASE_DOCUMENTATION_AND_PROVENANCE_ONLY",
+    "NO_GOVERNING_PHYSICS_CHANGE",
+    "NO_SCIENTIFIC_RESULT_CHANGE"
+  ],
+  "release": {
+    "tag": "v0.2.0",
+    "tag_target": "6e6b35b0fc6747f805223ce7975a0865835f01f0",
+    "url": "https://github.com/trbrewer/espresso-whole-pull/releases/tag/v0.2.0",
+    "pull_request": 21,
+    "merge_method": "MERGE_COMMIT",
+    "merge_commit": "6e6b35b0fc6747f805223ce7975a0865835f01f0",
+    "merge_tree": "ab91b7a479da6af5928e5acc378317a07ba0e619",
+    "required_ci": {
+      "source_and_boundary": "PASS",
+      "inexpensive_checks": "PASS"
+    }
+  },
+  "published_assets": {
+    "count": 10,
+    "digests": {
+      "WP02_001_POST_MERGE_CLOSURE.json": "b10a9fcbbd01cae763ec104fbceae2550fe9582ac8b49307d25ae30c234f5e11",
+      "WP02_001_SCIENTIFIC_REVIEW.json": "50109d18900dc78e29b362c6dfc410bab63d2ff6b77bf5c6e1cc9bf13283dce1",
+      "WP02_001_VERIFICATION_AND_RESULTS.json": "75a79e9972176668a8bfdb574ea16cbf39373a9ea11078009bc7b997c2f76859",
+      "WP_0_2F_FINAL_TERMINAL_RELEASE_MANIFEST.json": "fe4c64af5cbb859793bdc0170ef1674b7584effce0f26a2b40836f3d247d3550",
+      "WP_0_2F_RELEASE_ARCHIVE_CHECKSUMS.json": "61d78349c48885e2caffccd73011b3e4c2bb7d2164e87388c57d0065bcedaa9c",
+      "WP_0_2F_RELEASE_BUILD_IDENTITY.json": "49b4a1a2368f731ed690643b305c4e8607cd3583033cc48a0553df109c76870b",
+      "WP_0_2F_RELEASE_QA_RECORD.json": "dc8fc029ebf695f1312ffdba5a4e59cf35c0fa1edf5036333575d2a55e2ec3b0",
+      "WP_0_2F_TERMINAL_RELEASE_MANIFEST.json": "4489c1f9ed858a730a9d2039ba4509ea166fa918a9289b7b3a98dccc9acccb5c",
+      "espresso-whole-pull-0.2.0-source.tar.gz": "1d82f925877a3fc913d29494a777741f4c45e8944c4dac5bdb69ebba5d7a7141",
+      "espressoWholePullFoam-v0.2.0": "5af892d6382cbc47fa2e6b505fccacf7390bb42bc8d7177106620a43fb26c97b"
+    }
+  },
+  "immutable_identities": {
+    "final_published_terminal_manifest_sha256": "fe4c64af5cbb859793bdc0170ef1674b7584effce0f26a2b40836f3d247d3550",
+    "deterministic_source_archive_sha256": "1d82f925877a3fc913d29494a777741f4c45e8944c4dac5bdb69ebba5d7a7141",
+    "release_executable_sha256": "5af892d6382cbc47fa2e6b505fccacf7390bb42bc8d7177106620a43fb26c97b",
+    "historical_scientific_executable_sha256": "39056c46c74c53a254e969d02f989ce720dfb567924a90c2f5f8d3b661469ba0",
+    "scientific_result_sha256": "75a79e9972176668a8bfdb574ea16cbf39373a9ea11078009bc7b997c2f76859",
+    "candidate_tracked_terminal_manifest_sha256": "4489c1f9ed858a730a9d2039ba4509ea166fa918a9289b7b3a98dccc9acccb5c"
+  },
+  "tagged_tree_contains_prepublication_status_snapshot": true,
+  "final_publication_state_is_bound_by_release_asset_manifest": true,
+  "tag_changed": false,
+  "release_assets_changed": false,
+  "scientific_records_changed": false,
+  "protected_accesses_added": 0,
+  "analyzer_invocations_added": 0,
+  "governed_solver_executions_added": 0,
+  "score_recalculations_added": 0,
+  "fitting_or_retuning": false,
+  "physical_validation": "NOT_ESTABLISHED",
+  "allowed_post_release_changed_paths": [
+    "PACKAGE_QA_STATUS.json",
+    "README.md",
+    "SOURCE_PACKAGE_MANIFEST.json",
+    "docs/DEVELOPMENT_HISTORY.md",
+    "docs/PROJECT_STATE.md",
+    "docs/QA_STATUS.md",
+    "docs/source_strategy/espresso_puck_modeling_and_simulation_strategy_v1_4.md",
+    "scripts/generate_source_manifest.py",
+    "scripts/verify_release_finalization.py",
+    "tests/test_change_contract.py",
+    "validation/release/WP_0_2G_POST_RELEASE_STATE_RECONCILIATION.json"
+  ]
+}


### PR DESCRIPTION
## Classification

- POST_RELEASE_DOCUMENTATION_AND_PROVENANCE_ONLY
- NO_GOVERNING_PHYSICS_CHANGE
- NO_SCIENTIFIC_RESULT_CHANGE

## Scope

Reconciles current-main state with the published v0.2.0 release, adds the publication-bound closure record, and advances the controlling strategy to v1.4. The tagged tree remains an immutable prepublication snapshot; the final publication state is bound by the published terminal-manifest asset.

## Frozen identities

- v0.2.0 target: `6e6b35b0fc6747f805223ce7975a0865835f01f0`
- scientific result: `75a79e9972176668a8bfdb574ea16cbf39373a9ea11078009bc7b997c2f76859`
- closure contract: `2c898dd91e558ce62006dc81de9cff20bb633b52a89f6fa5a44c5edcda50d57a`
- published terminal manifest: `fe4c64af5cbb859793bdc0170ef1674b7584effce0f26a2b40836f3d247d3550`
- source archive: `1d82f925877a3fc913d29494a777741f4c45e8944c4dac5bdb69ebba5d7a7141`

## Verification

- Python: 121/121 PASS
- active static gates: 34/34 PASS
- current source manifest: 132/132 PASS, aggregate `90fd3023e9b97b1b42b0e1cfa25c7e76858ce40a00b0fec69881ab8bfeced651`
- historical v0.1.4 integrity: PASS
- active governing-change boundary: PASS
- release-finalization boundary: PASS
- shell and JSON syntax: PASS

No OpenFOAM execution, protected access, analyzer invocation, score recalculation, fitting, retuning, tag change, release-asset change, or scientific-record change occurred. Physical validation remains `NOT_ESTABLISHED`.
