### PR TITLE
docs: align roadmap around post-WP03-001 validation pivot

### DIFF
--- a/PACKAGE_QA_STATUS.json
+++ b/PACKAGE_QA_STATUS.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "espresso.whole_pull.package_qa.v0.2.0",
   "package_version": "0.2.0",
-  "current_governance_milestone": "WP03-001_POROELASTIC_COMPACTION",
+  "current_governance_milestone": "POST_WP03_001_VALIDATION_AND_MECHANISM_DISCRIMINATION",
   "release_scope": {
     "scientific_milestone": "WP-0.2F",
     "release_role": "NO_GOVERNING_PHYSICS_RELEASE_FINALIZATION"
@@ -29,7 +29,7 @@
     "python_test_count": 230,
     "static_gate_count": 34,
     "source_manifest_file_count": 179,
-    "source_manifest_aggregate_sha256": "e756c82016f57d0c2bfaf06aa3dbbd9c446f669bc63dcd45810db705c2d502e8",
+    "source_manifest_aggregate_sha256": "07a47f00db329dbd424ede52e4b0e60581973aad78fefa874f34c169c0a38759",
     "historical_baseline_integrity": "PASS",
     "active_governing_change_contract": "PASS",
     "release_integrity": "PASS",
@@ -77,6 +77,17 @@
     "case_completion": "PASS",
     "physical_validation": "NOT_ESTABLISHED"
   },
+  "post_wp03_001_validation_pivot": {
+    "change": "STRATEGY_AND_ROADMAP_ALIGNMENT",
+    "governing_physics_change": false,
+    "model_execution": false,
+    "validation_execution": false,
+    "experimental_authorization": false,
+    "dependency_lock_change": false,
+    "claim_ceiling_expansion": false,
+    "active_phase": "POST_WP03_001_VALIDATION_AND_MECHANISM_DISCRIMINATION",
+    "physical_validation": "NOT_ESTABLISHED"
+  },
   "wp_0_3b_amendment_state": {
     "original_result": "NONPROTECTED_REFERENCE_VERIFICATION_FAIL",
     "commit_3a": "TRANSCRIPTION_AND_DERIVATION_CHECKPOINT",
@@ -112,6 +123,6 @@
   "wp_0_3a_contract_status": "FROZEN_NO_EXECUTION_NO_QUALIFYING_HYDRAULIC_HOLDOUT",
   "wp_0_3a_solver_support_evidence_disposition": "ADOPT_SELECTED_EVIDENCE_WITH_FOLLOWUP",
   "wp_0_3a_runtime_dependency_lock_disposition": "RETAIN_EXISTING_LOCK",
-  "next_scientific_milestone": "INDEPENDENT_HYDRAULIC_CAMPAIGN_ACQUISITION_AND_PRE_REGISTRATION",
+  "next_scientific_milestone": "VAL_001_SOURCE_SPECIFIC_VALIDATION_ADAPTER_FRAMEWORK_AND_FIRST_COMPONENT_COMPARISONS",
   "claim_ceiling": "Software and source-linked reconstruction release only; independent physical validation and universal transfer remain NOT_ESTABLISHED."
 }

--- a/README.md
+++ b/README.md
@@ -2,18 +2,27 @@
 
 OpenFOAM-based research solver for espresso-puck wetting, porous flow, extraction, and multiscale integration with Puckworks.
 
-> **Research software:** v0.2.0 finalizes WP-0.2A. It
-> adds one optional governing-physics closure while preserving the immutable
-> v0.1.4-public.1 R0 baseline and constant R1 control. Physical validation is
-> **NOT_ESTABLISHED**.
+> **Research software:** Hydraulic integration through static radial
+> heterogeneity and saturated quasi-static compaction are merged. The active
+> phase is source-specific validation and mechanism discrimination. Physical
+> validation is **NOT_ESTABLISHED**.
 
 The approximately 40 g beverage endpoint at 30 s was used in the saturated-permeability calibration. It is not an independent prediction or validation target. The software does not yet predict taste.
 
 ## Current scope
 
-The current Foundation OpenFOAM 12 model represents initially dry sharp-front wetting, saturated Darcy flow, one-solute conservative transport and extraction, retained inventories, and cup accumulation.
+The Foundation OpenFOAM 12 model represents initially dry sharp-front wetting,
+prescribed or machine-coupled pressure, Darcy and Darcy–Forchheimer saturated
+flow, static axial/radial permeability heterogeneity, optional evolving
+effective permeability, saturated quasi-static compaction, one-solute
+conservative transport and extraction, spatial diagnostics, retained
+inventories, and cup accumulation.
 
-Evolving structure, fines migration, channeling, thermal coupling, and multispecies chemistry are roadmap capabilities, not implemented or validated capabilities of R0. Taste and transfer across coffees, grinders, baskets, machines, and recipes are not yet predicted.
+The post-WP03-001 roadmap now confronts existing branches with evidence,
+uncertainty and identifiability analysis before choosing further governing
+physics. Fines migration, dynamic channeling, thermal coupling and multispecies
+chemistry remain evidence-selected candidates. Taste and transfer are not
+predicted.
 
 The frozen archival R0 baseline is `FROZEN / QUALIFIED` at the numerical and provenance levels. The public source is not byte-identical to that offline archive because host and path metadata were sanitized. The 19-file scientific-input bundle and governing physics are unchanged.
 
@@ -26,6 +35,13 @@ Full generated fields, uncleaned runs, processor directories, compiled executabl
 - Sanitization proof: `provenance/PUBLIC_SANITIZATION_REPORT.json`
 - Compact baseline summary: `validation/baselines/v0.1.4/PUBLIC_BASELINE_SUMMARY.json`
 - Claim ceiling: `docs/CLAIM_CEILING.md`
+- Controlling strategy:
+  `docs/strategy/WHOLE_PULL_MODELING_AND_SIMULATION_STRATEGY.md`
+- Concise roadmap:
+  `docs/strategy/SOLVER_DEVELOPMENT_AND_VALIDATION_ROADMAP.md`
+- Validation action plan:
+  `docs/validation/POST_WP03_001_VALIDATION_AND_MECHANISM_DISCRIMINATION_PLAN.md`
+- Current project state: `docs/PROJECT_STATE.md`
 
 ## Development
 
@@ -49,9 +65,10 @@ The published release and bounded assets are available at
 [v0.2.0](https://github.com/trbrewer/espresso-whole-pull/releases/tag/v0.2.0).
 WP-0.3A reviewed the moving Puckworks evidence baseline and found no presently
 qualifying independent hydraulic holdout. Its frozen contract authorizes no
-execution and no additional mechanism. The next evidence task is to acquire
-the independently instrumented pressure/flow campaign specified by that
-contract; physical validation remains **NOT_ESTABLISHED**.
+execution and no additional mechanism. The next implementation task is the
+validation-adapter framework and first admissible component comparisons.
+Experimental commissioning, protected scoring and holdout execution remain
+unauthorized; physical validation remains **NOT_ESTABLISHED**.
 
 ## License
 

--- a/SOURCE_PACKAGE_MANIFEST.json
+++ b/SOURCE_PACKAGE_MANIFEST.json
@@ -27,9 +27,9 @@
     "deterministically generated case dictionaries and case/0 fields"
   ],
   "file_count": 179,
-  "total_uncompressed_bytes_excluding_manifest": 1709663,
-  "aggregate_source_sha256": "e756c82016f57d0c2bfaf06aa3dbbd9c446f669bc63dcd45810db705c2d502e8",
-  "aggregate_sha256": "e756c82016f57d0c2bfaf06aa3dbbd9c446f669bc63dcd45810db705c2d502e8",
+  "total_uncompressed_bytes_excluding_manifest": 1712307,
+  "aggregate_source_sha256": "07a47f00db329dbd424ede52e4b0e60581973aad78fefa874f34c169c0a38759",
+  "aggregate_sha256": "07a47f00db329dbd424ede52e4b0e60581973aad78fefa874f34c169c0a38759",
   "strategy_source_path": "docs/source_strategy/espresso_puck_modeling_and_simulation_strategy_v1_4.md",
   "strategy_source_sha256": "3e3b96b39f81c5e2df5c2dbe42103a4a5a58f928b9e5409bbcaeb861761377b9",
   "files": {
@@ -59,8 +59,8 @@
       "git_mode": "100644"
     },
     "README.md": {
-      "sha256": "4e88d88afa24e0c8e92646670e1638830f9260196c9b6d3e93da57e609164706",
-      "bytes": 4077,
+      "sha256": "435c1ab53d0c6928a2551a3e0f7df728d2bffd0a640c604048d8130712f20281",
+      "bytes": 4759,
       "git_mode": "100644"
     },
     "VERSION": {
@@ -399,8 +399,8 @@
       "git_mode": "100644"
     },
     "docs/FILE_TREE.md": {
-      "sha256": "9d8af51ff11dd7ac68c75ba727e6675b0067ed5102472c079444da8d1acfd3d6",
-      "bytes": 3306,
+      "sha256": "ba1a306c2d1023f578ab9221ce39f4d7f8eb60875f764e9adca459fd29e161f7",
+      "bytes": 3762,
       "git_mode": "100644"
     },
     "docs/FREEZE_FINALIZATION_SPECIFICATION_V0_1_4.md": {
@@ -444,8 +444,8 @@
       "git_mode": "100644"
     },
     "docs/QA_STATUS.md": {
-      "sha256": "1abe35d72735b0dbd4d0c204237ada712453e888143a40e0829ae88b52a0d530",
-      "bytes": 2722,
+      "sha256": "99265da599b394941c18ec970a22a62ef52bd4412b62cde64aa505d6290a8f57",
+      "bytes": 3191,
       "git_mode": "100644"
     },
     "docs/RUNBOOK_AND_TROUBLESHOOTING.md": {
@@ -554,8 +554,8 @@
       "git_mode": "100755"
     },
     "scripts/generate_source_manifest.py": {
-      "sha256": "f65fff1ac32e4b02edcbc84916974f445381eccdfd84d9fbd52a3a3289f2cc77",
-      "bytes": 8935,
+      "sha256": "19fb99efe9bee76dcd39d08c5b52cb75dac50c845cd8c63eceb2303447518a68",
+      "bytes": 9086,
       "git_mode": "100755"
     },
     "scripts/lib/openfoam_env.sh": {
@@ -729,8 +729,8 @@
       "git_mode": "100755"
     },
     "scripts/verify_wp03c_stage0_scaffold.py": {
-      "sha256": "f10eb4ca5984d7c02c2899f82afb8cf4fe768fed1f15b0da73fa4fa39d07e26d",
-      "bytes": 30613,
+      "sha256": "be8170866834c70519d3212a631aac2498d501a382476a48ca11266857fa75ca",
+      "bytes": 31547,
       "git_mode": "100755"
     },
     "scripts/waszkiewicz_effective_permeability.py": {
@@ -864,8 +864,8 @@
       "git_mode": "100644"
     },
     "tests/test_reference_case.py": {
-      "sha256": "aac1ca125625447b5de34179ef04fcda0d6e3617d9e5df5d8c76a1a2346f7ad0",
-      "bytes": 64870,
+      "sha256": "9647dfc42a133d5dd1da480a2bb2b75a09ca67122e95ceae16a5053708880e20",
+      "bytes": 64822,
       "git_mode": "100644"
     },
     "tests/test_wp02_002_machine_coupling.py": {

--- a/docs/DEVELOPMENT_HISTORY.md
+++ b/docs/DEVELOPMENT_HISTORY.md
@@ -38,3 +38,28 @@ commissioning or holdout data, creates no final preregistration, and performs
 no model execution or scoring. Review hardening binds the frozen WP-0.3A
 campaign requirements and requires exact deterministic registry/template
 regeneration before readiness can be reported.
+
+## WP02 and WP03 first-generation solver extensions
+
+- **WP02-002:** lumped upstream resistance and compliance made basket pressure
+  emergent and changed synthetic wetting, pressure, flow and cup histories.
+- **WP02-003:** saturated Darcy–Forchheimer resistance added nonlinear regime
+  diagnostics and exposed a compatibility concern when added to permeability
+  previously calibrated under Darcy assumptions.
+- **WP02-004:** static radial two-zone permeability showed that matched bulk
+  Darcy conductance can conceal substantial synthetic extraction
+  maldistribution.
+- **WP03-001:** saturated quasi-static compaction added pressure-dependent
+  mechanical porosity and permeability. It uses a fixed mesh and does not
+  couple mechanical porosity to transport storage.
+
+These work packages are numerically verified for their tested cases and do not
+establish physical validation.
+
+## Post-WP03-001 validation pivot
+
+Completion of WP03-001 triggered the planned validation-led development
+tranche. The program will now build source-specific adapters, compare existing
+mechanisms with admissible real evidence, quantify uncertainty and
+identifiability, decompose residuals, and select one next physics increment
+from information value rather than implementation convenience.

--- a/docs/FILE_TREE.md
+++ b/docs/FILE_TREE.md
@@ -1,5 +1,14 @@
 # Package file tree — v0.1.4
 
+This tree is the historical v0.1.4 package view. Current navigation:
+
+- [Project state](PROJECT_STATE.md)
+- [Claim ceiling](CLAIM_CEILING.md)
+- [Puckworks integration](PUCKWORKS_INTEGRATION.md)
+- [Controlling strategy](strategy/WHOLE_PULL_MODELING_AND_SIMULATION_STRATEGY.md)
+- [Concise roadmap](strategy/SOLVER_DEVELOPMENT_AND_VALIDATION_ROADMAP.md)
+- [Post-WP03 validation plan](validation/POST_WP03_001_VALIDATION_AND_MECHANISM_DISCRIMINATION_PLAN.md)
+
 ```text
 .
 ├── Allrun

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1,6 +1,10 @@
 # Onboarding
 
-Read `README.md`, `docs/PROJECT_STATE.md`, `docs/CLAIM_CEILING.md`, the controlling strategy, and `CONTRIBUTING.md`.
+Read `README.md`, `docs/PROJECT_STATE.md`, `docs/CLAIM_CEILING.md`, the
+[controlling strategy](strategy/WHOLE_PULL_MODELING_AND_SIMULATION_STRATEGY.md),
+the [concise roadmap](strategy/SOLVER_DEVELOPMENT_AND_VALIDATION_ROADMAP.md),
+the [post-WP03 validation plan](validation/POST_WP03_001_VALIDATION_AND_MECHANISM_DISCRIMINATION_PLAN.md),
+[Puckworks integration](PUCKWORKS_INTEGRATION.md), and `CONTRIBUTING.md`.
 
 ## Governed issues and pull requests
 

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -1,121 +1,69 @@
 # Project State
 
 - Current released version: `v0.2.0`
+- Current merged `main`: `f475eef5c7a93f833a51ce03485c557ce0620b8d`
+- Current merged tree: `493934e1d9e30461c9ca289dcc82ad43084eaf4b`
 - Public baseline: `v0.1.4-public.1`, immutable sanitized R0 derivative
 - Archival baseline: WP-0.1H v0.1.4, `FROZEN / QUALIFIED`
-- Public source verification: 179/179 PASS (WP03-001 development branch)
-- Published v0.2.0 source verification: 131/131 PASS
-- Scientific inputs: 19/19 byte-identical to archival baseline
-- Frozen R0 scientific-configuration change: false
-- Governed R1 scenario present: true
-- WP01R-005 R1 scenario change: false
-- Governing-physics change in WP01R-005: false
-- Governing-physics change in WP02-001: true
-- WP02 optional closure added: true
-- Release qualification: `PASS`
-- Release disposition: `SOFTWARE_AND_SOURCE_LINKED_RECONSTRUCTION_RELEASE_PASS`
-- R0 claim ceiling: `NUMERICALLY_QUALIFIED_CALIBRATION_BASELINE`
-- Physical validation: `NOT_ESTABLISHED`
 - OpenFOAM target: Foundation 12
 - Puckworks integration: locked external checkout, no submodule
+- Public source verification: 179/179 PASS
+- Active phase: `POST_WP03_001_VALIDATION_AND_MECHANISM_DISCRIMINATION`
+- Physical validation: `NOT_ESTABLISHED`
+- Experimental commissioning: `NOT_AUTHORIZED`
+- Protected or holdout scoring: `NOT_AUTHORIZED`
 
-WP02-003 adds an optional, disabled-by-default saturated Darcy–Forchheimer
-branch with constant and fixed Wadsworth-2026 ceramics-fit inertial
-permeability models. Foundation OpenFOAM 12 scalar, uniform, layered, machine,
-Darcy-limit, nonlinear, conservation, flux-consistency, wetting-isolation, and
-full-shot refinement gates pass. The source-linked branch is a synthetic
-mechanism diagnostic applied to a permeability calibrated under Darcy
-assumptions; it is not an improved prediction or physical validation.
-The bounded result-evidence correction reconstructs the published Fo band
-under both candidate source closures, exercises the production zero-inertia
-path, and adds explicit R0, WP02-002 MC-2, WP02-002 MC-5, and
-coupling-disabled predecessor gates. All corrected adjudication gates pass;
-the identified source-closure inconsistency does not change the implemented
-ceramics equation.
+The exact source-manifest count and aggregate are generated in
+[`SOURCE_PACKAGE_MANIFEST.json`](../SOURCE_PACKAGE_MANIFEST.json).
 
-WP02-004 adds an optional saturated-only static radial two-zone permeability
-profile. Exact parallel Darcy and Darcy–Forchheimer fixtures, nested machine
-operating-point roots, matched-conductance full shots, zone-resolved flow and
-extraction accounting, timestep refinement, and 256/512/1024-cell radial
-refinement pass. Matched bulk Darcy flow conceals substantial synthetic
-spatial extraction maldistribution. This is a numerical verification and
-synthetic mechanism diagnostic, not physical validation or dynamic channel
-growth. The bounded diagnostic correction applies the geometric inner/outer
-split independently of permeability assignment, verifies complete zone
-inventories and uniform-profile symmetry, makes combined traces
-self-identifying, and requires finite monotonic traces to reach their
-configured end time. All corrected gates pass without changing aggregate
-radial-case hydraulic or cup results.
+## Completed sequence
 
-WP03-001 adds an optional saturated-only finite-porosity quasi-static
-compaction branch. Exact constitutive, scalar pressure-flow, source
-reconstruction, 5/9/11-bar field, rigid-limit, matched-reference, nested
-machine, timestep, axial-mesh, bounded-state, and conservation gates pass.
-Mechanical porosity changes hydraulic permeability but remains deliberately
-uncoupled from transport storage on the fixed reference mesh. The
-source-linked and R0-compatibility results are numerical mechanism
-diagnostics, not physical validation or a complete transient Biot model.
+- **WP-0.1:** reference whole-pull implementation — complete.
+- **WP-0.1H:** numerical hardening and frozen R0 qualification — complete,
+  frozen and qualified.
+- **WP01R:** source-linked reconstruction and residual assessment — complete
+  with a structural residual; not independent physical validation.
+- **WP02-001:** optional dissolution-indexed effective permeability — complete.
+- **WP02-002:** lumped machine/headspace compliance and emergent basket
+  pressure — complete.
+- **WP02-003:** saturated Darcy–Forchheimer resistance and regime diagnostics
+  — complete.
+- **WP02-004:** static radial permeability heterogeneity with zone-resolved
+  flow and extraction — complete.
+- **WP03-001:** saturated finite-porosity quasi-static compaction — complete.
 
-WP01R-001 dependency review is complete. Puckworks is locked to reviewed
-`main` snapshot `fc61c4670ec7bf801e40bb391aab16048b8da26b` with recommendation
-`ADOPT_WITH_FOLLOWUP`. WP01R-002 through WP01R-005 are merged, and issue #7
-is complete. WP01R-005
-completed one governed R1 execution and an explicitly non-blinded protected
-comparison without retuning. Numerical, conservation, and calibration gates
-passed; the protected flow-shape gate failed and exactly reproduced the
-preliminary PR #16 disposition. R0 remains frozen and unchanged. Physical
-validation is `NOT_ESTABLISHED`.
+WP03-001 changes mechanical porosity and hydraulic permeability under
+effective stress and composes with the machine operating-point calculation.
+It is inactive during wetting and uses a fixed reference mesh. It does not
+solve solid displacement or couple mechanical porosity to transport storage,
+and it excludes transient Biot storage, plasticity, hysteresis, swelling,
+fines, damage and dynamic channeling. Its tested cases are numerically
+verified; physical validation is not established.
 
-WP-0.2F successfully published v0.2.0. WP01R-006 selected the Waszkiewicz saturated dissolution-indexed
-effective-permeability branch for WP-0.2A. WP02-001 implemented and tested it,
-merged through PR #20, and is scientifically closed. WP-0.2F release
-finalization and WP-0.2G post-release reconciliation are complete. WP-0.3A
-reviewed moving-upstream Puckworks evidence and froze the independent-holdout
-and mechanism-discrimination contract without execution. No currently
-reviewed candidate qualifies as an independent hydraulic holdout. The
-solver-support triage adopts bounded evidence corrections, analytic
-verification targets, and an inactive Vaca Guerra prior specification without
-advancing the dependency lock. The next evidence task is the specified
-independent pressure/flow campaign. Independent
-physical validation has not started. Machine/headspace coupling remains a
-later hypothesis subject to holdout evidence and a separate decision.
+## Current merged capabilities
 
-WP-0.3B implements non-protected Moroney, Matias, and Liang mathematical
-references plus method-explicit TDS, EY, and retained-liquid measurement
-kernels. They are verification support only, are not connected to WP02, and
-do not establish physical validation. The canonical run passed Matias, Liang,
-and observable gates but failed the predeclared Moroney timestep-refinement
-ratio gate; the result remains a governed verification failure without
-tolerance relaxation.
+The solver includes dry-puck sharp-front wetting, first drip, prescribed or
+lumped-machine pressure boundaries, upstream resistance and compliance,
+Darcy and Darcy–Forchheimer saturated flow, uniform/axial/radial permeability
+profiles, optional dissolution-indexed effective permeability, quasi-static
+compaction, conservative one-solute transport, spatial extraction diagnostics,
+cup accumulation, and water/solute conservation reporting.
 
-WP-0.3B-A1-P1 preserves that failure and the subsequent transcription and
-derivation checkpoint. Commit 3B froze the state
-`PREEXECUTION_FROZEN_AWAITING_CANONICAL_RESULT` before the amended invocation.
-The P1 boundary corrects generated-path handling, historical-runner
-reachability, observable uncertainty propagation, and Python 3.8 portability
-without changing a scientific threshold.
+R0 remains frozen and unchanged. Source-linked and synthetic mechanism
+diagnostics are not improved predictions merely because they add complexity.
 
-The one P1-bound amended canonical invocation subsequently passed every
-Moroney, Matias, Liang, and observable subgate. Its disposition is
-`NONPROTECTED_EXTRACTION_REFERENCE_AND_OBSERVABLE_VERIFICATION_PASS_AFTER_GOVERNED_AMENDMENT`.
-The original governed FAIL remains unchanged and independently addressable.
-This mathematical and measurement verification does not establish physical
-validation.
+## Active next program phase
 
-WP02-001 added the optional saturated dissolution-indexed effective-permeability
-closure. Its corrected uniform fixture, disabled R0 regression, and disabled
-constant-R1 regression passed. One governed 9-bar source-linked reconstruction
-and one predeclared 8-bar no-retuning same-campaign comparison both passed their
-frozen flow-shape gates. A retained-trace endpoint representation correction
-was committed before the sole score-bearing analysis; neither solver was
-rerun, and no fitting or post-result adjustment occurred. These same-campaign
-results do not establish independent validation. Physical validation remains
-`NOT_ESTABLISHED`.
+No governing physics changes and no validation executions occur in this
+documentation alignment task. The next recommended implementation is a
+source-specific validation adapter framework with first component
+comparisons. It will preserve evidence definitions and rights, separate
+calibration from comparison, quantify uncertainty and identifiability, compare
+existing mechanisms, and recommend one next physics increment from residuals.
 
-WP-0.3C Stage 0 has begun as a protocol and input-intake scaffold. No final
-preregistration exists, no commissioning or holdout acquisition has occurred,
-and no model execution or scoring has occurred. Human, apparatus,
-instrumentation, calibration-resource, material, and custody inputs remain
-required. Readiness fails closed on incomplete or mismatched packages and a
-complete package still requires separate governed review. Physical validation
-remains `NOT_ESTABLISHED`.
+See the concise
+[solver development and validation roadmap](strategy/SOLVER_DEVELOPMENT_AND_VALIDATION_ROADMAP.md)
+and the
+[post-WP03-001 validation and mechanism-discrimination plan](validation/POST_WP03_001_VALIDATION_AND_MECHANISM_DISCRIMINATION_PLAN.md).
+
+General whole-solver physical validation remains `NOT_ESTABLISHED`.

--- a/docs/PUCKWORKS_INTEGRATION.md
+++ b/docs/PUCKWORKS_INTEGRATION.md
@@ -59,7 +59,8 @@ effective-permeability closure as the first WP-0.2 branch. See the
 The first branch is source-linked and softly circular, implements effective
 hydraulic resistance only, and is not independent validation. WP02-001
 completed the governed implementation under issue #18, and issue #18 is
-closed; machine/headspace coupling remains the runner-up.
+closed. Machine/headspace coupling, Darcy–Forchheimer resistance, static
+radial heterogeneity, and quasi-static compaction have since been completed.
 
 WP02-001 executed the locked branch once at 9 bar and once at the predeclared
 8-bar same-campaign group. The compact
@@ -106,3 +107,29 @@ WP-0.3B independently re-expresses the selected Moroney, Matias, and Liang
 references without importing or executing Puckworks. These are offline
 verification and observable-discipline tools only; the runtime dependency
 lock and WP02 branch remain unchanged.
+
+## Puckworks role in the post-WP03-001 validation tranche
+
+Puckworks supplies evidence identities, source definitions, rights and
+redistribution status, model cards, data manifests, exact experimental
+campaign definitions, evidence levels, source uncertainties, known
+circularity, validation ceilings, and model-to-measurement mappings.
+
+Espresso-whole-pull supplies source adapters, executable source-specific cases,
+whole-shot and component predictions, common comparison metrics, uncertainty
+propagation, residual decomposition, sensitivity and identifiability analysis,
+mechanism-discrimination results, and experimental-design priorities.
+
+The dependency lock remains unchanged unless a separate dependency review
+authorizes advancement. Evidence classes and quantity definitions must be
+preserved. Source and post-fit reconstruction are not independent validation,
+and within-apparatus evidence is not universal transfer. Protected or holdout
+observations are not opened by this plan; missing source values remain
+unresolved.
+
+The retained EXP-001 through EXP-009 campaign identities are used exactly as
+named in Puckworks. Their inclusion is planning only and authorizes neither
+commissioning nor acquisition.
+
+The active phase and adapter requirements are detailed in the
+[Post-WP03-001 Validation and Mechanism-Discrimination Plan](validation/POST_WP03_001_VALIDATION_AND_MECHANISM_DISCRIMINATION_PLAN.md).

--- a/docs/QA_STATUS.md
+++ b/docs/QA_STATUS.md
@@ -40,7 +40,7 @@ and source/holdout-fit counts remained zero.
 
 ## Current repository checks
 
-- Python tests: 199/199 PASS
+- Python tests: 230/230 PASS at the merged WP03-001 baseline
 - active static gates: 34/34 PASS
 - source manifest: recorded in `PACKAGE_QA_STATUS.json` and
   `SOURCE_PACKAGE_MANIFEST.json`
@@ -62,11 +62,21 @@ Physical validation remains `NOT_ESTABLISHED`.
 
 ## WP-0.3C Stage-0 scaffold
 
-The current governance milestone is WP-0.3C Stage 0. Requirements,
+WP-0.3C Stage 0 remains a completed, frozen scaffold. Requirements,
 public/private intake templates, and readiness validation are present.
 Real-world human and apparatus inputs remain unresolved. Final
 preregistration, commissioning, holdout acquisition, model execution, and
 scoring are not authorized.
 
-Current Stage-0 checks comprise 199/199 Python tests, 34/34 active static
-gates, and 143/143 source-manifest entries.
+Its historical completion counts are retained in its result records.
+
+## Post-WP03-001 phase
+
+WP03-001 is merged and numerically verified for its tested cases. The active
+program phase is source-specific validation and mechanism discrimination.
+This documentation alignment performs no model or validation execution and
+authorizes no experiment, protected scoring or holdout opening.
+
+Current test and source-manifest identities are generated in
+`PACKAGE_QA_STATUS.json` and `SOURCE_PACKAGE_MANIFEST.json`. Physical
+validation remains `NOT_ESTABLISHED`.

--- a/docs/strategy/SOLVER_DEVELOPMENT_AND_VALIDATION_ROADMAP.md
+++ b/docs/strategy/SOLVER_DEVELOPMENT_AND_VALIDATION_ROADMAP.md
@@ -1,0 +1,117 @@
+# Solver Development and Validation Roadmap
+
+## Purpose
+
+This is the concise current / next / later roadmap. The long-form controlling
+rationale is the [Whole-Pull Modeling and Simulation Strategy](WHOLE_PULL_MODELING_AND_SIMULATION_STRATEGY.md).
+
+## Current merged platform
+
+The merged Foundation OpenFOAM 12 solver provides:
+
+- dry-puck sharp-front wetting and physical first-drip prediction within the
+  current model;
+- prescribed-pressure and lumped machine/headspace boundaries, upstream
+  resistance and compliance, and emergent basket pressure;
+- saturated Darcy and Darcy–Forchheimer flow;
+- uniform, axial two-layer and radial two-zone permeability;
+- optional dissolution-indexed effective permeability;
+- quasi-static pressure-dependent compaction;
+- conservative one-solute transport with extractable and retained inventories;
+- spatial flow and extraction diagnostics;
+- cup mass, TDS, extraction yield, water balance and solute balance; and
+- serial/MPI execution with analytical, regression, conservation, timestep
+  and mesh verification.
+
+```text
+PHYSICAL_VALIDATION:
+  NOT_ESTABLISHED
+```
+
+## Current active phase
+
+```text
+POST-WP03-001 VALIDATION AND MECHANISM DISCRIMINATION
+```
+
+### Workstream 1 — Validation-case framework
+
+Develop a common source-adapter schema, preserve source definitions, classify
+rights and evidence, separate calibration from comparison, represent
+uncertainty, calculate common metrics, and retain machine-readable bundles and
+standard reports.
+
+### Workstream 2 — Component comparisons
+
+Compare wetting and first drip, steady pressure–flow behavior, permeability,
+machine pressure nodes and delivery, quasi-static compaction, aggregate
+extraction and cup chemistry, and spatial maldistribution where evidence
+permits.
+
+### Workstream 3 — Limited coupled comparisons
+
+Compare multiple synchronized observables from the same apparatus or study.
+Report the result as apparatus- and source-specific, not universal validation.
+
+### Workstream 4 — Sensitivity and identifiability
+
+Assess parameter influence and correlation, equifinality, uncertainty
+propagation, observable information value, and transfer across pressure,
+recipe and apparatus conditions.
+
+### Workstream 5 — Mechanism discrimination
+
+Compare compatible existing branches on common cases: constant permeability,
+dissolution-indexed permeability, machine compliance, Darcy–Forchheimer
+resistance, static radial heterogeneity and quasi-static compaction.
+
+### Workstream 6 — Experimental design
+
+Use unresolved sensitivities and residuals to rank future measurements. This
+roadmap does not authorize commissioning or acquisition.
+
+## Exit criteria
+
+The tranche should produce at least:
+
+1. one real-data wetting or first-drip comparison;
+2. one real-data saturated hydraulic comparison;
+3. one limited coupled pressure/flow comparison;
+4. one aggregate extraction comparison;
+5. explicit calibration-versus-comparison separation;
+6. uncertainty bounds;
+7. an identifiability assessment;
+8. a mechanism-discrimination report;
+9. a ranked next-physics recommendation; and
+10. an updated experimental-data request.
+
+Universal whole-solver validation is not an exit criterion.
+
+## Later, selected by evidence
+
+| Observed residual or discriminating evidence | Candidate next increment |
+|---|---|
+| Pressure/flow residual correlated with measured bed compression | Fuller poroelastic deformation or storage |
+| Flow decay correlated with measured particle or bed expansion | Swelling |
+| Flow changes correlated with concentration or viscosity | Concentration-dependent viscosity |
+| Turbidity, captured fines or deposition | Fines transport |
+| Repeatable localized outlet-flow or extraction defects | Non-axisymmetric channeling or damage |
+| Temperature-correlated hydraulic or extraction residual | Energy equation |
+| Species-specific extraction disagreement | Multispecies chemistry |
+| No discriminating evidence | Retain the simpler model and request better data |
+
+This table guides investigation; it does not authorize a mechanism.
+
+## Cadence rule
+
+```text
+complete a verified mechanism
+-> perform relevant real-data comparison
+-> assess sensitivity and identifiability
+-> select one next mechanism from residual evidence
+```
+
+> No two new evolving-puck governing mechanisms consecutively after WP03-001
+> without an intervening relevant real-data comparison.
+
+This is human-readable program guidance, not a CI or static-validation gate.

--- a/docs/strategy/WHOLE_PULL_MODELING_AND_SIMULATION_STRATEGY.md
+++ b/docs/strategy/WHOLE_PULL_MODELING_AND_SIMULATION_STRATEGY.md
@@ -1,9 +1,9 @@
 # Puckworks Whole-Pull Multiscale Modeling and Simulation Strategy
 
-**Strategy version:** 1.5
-**Date:** 29 July 2026
-**Status:** Controlling public-development workflow; WP-0.1R is complete, R0 remains `FROZEN / QUALIFIED`, and physical validation remains not established
-**Supersedes:** strategy v1.4 and all earlier strategy versions
+**Strategy version:** 1.6
+**Date:** 30 July 2026
+**Status:** Controlling solver-development and validation workflow; WP03-001 complete; post-WP03-001 validation and mechanism discrimination active; physical validation not established
+**Supersedes:** strategy v1.5 and all earlier strategy versions
 **Repository:** `trbrewer/espresso-whole-pull`; Puckworks remains the external evidence/model/data dependency
 **Reviewed Puckworks dependency baseline:** repository `https://github.com/trbrewer/puckworks.git`; commit `fc61c4670ec7bf801e40bb391aab16048b8da26b`; tree `1d553e44ee2f7480a5df521560801b478618cc84`; alignment status `REVIEWED_MAIN_AT_RECORDED_UTC_CUTOFF`. The dependency review, source dossier, calibration/comparison contract, deterministic R1 bridge, and governed WP-0.1R execution are complete.
 **OpenFOAM implementation baseline:** `espresso_puck_whole_pull_reference_v0_1_4_openfoam12`, terminal freeze manifest `PASS`
@@ -12,37 +12,61 @@
 **Primary pore-scale platform:** Taichi/LBM on NVIDIA A100-SXM4-80GB-class GPU resources
 **Scientific and software backbone:** Puckworks models, data, model cards, contracts, validation gates, rights records, and public product layer
 **WP-0.1 disposition:** **IMPLEMENTATION PASS; BOUNDED CODE VERIFICATION PASS; NUMERICAL QUALIFICATION PASS; RELEASE PROVENANCE PASS; R0 FROZEN / QUALIFIED; PHYSICAL VALIDATION NOT ESTABLISHED**
-**Next controlling milestone:** issue #18, WP02-001, implementing the optional Waszkiewicz saturated dissolution-indexed effective-permeability branch
+**Next controlling milestone:** Post-WP03-001 source-specific validation and mechanism discrimination
 
 ---
 
 ## Executive statement
 
-Version 1.5 records completion of WP-0.1R and selects the first evidence-led
-WP-0.2 mechanism. WP-0.1R passed numerical, conservation, and calibration
-reproduction gates, but failed the five protected flow-shape comparisons with
-zero predicted protected-window variation. The governed corrective result
-exactly reproduced the preliminary result. The controlling residual is
-`STRUCTURAL_MODEL_INADEQUACY`; physical validation remains
-`NOT_ESTABLISHED`.
+The program now has an executable modular whole-pull solver spanning initially
+dry wetting, first drip, prescribed or machine-coupled pressure, Darcy and
+Darcy–Forchheimer flow, evolving effective permeability, static axial and
+radial heterogeneity, conservative solute transport, spatial extraction
+diagnostics, cup accumulation, and saturated quasi-static compaction.
 
-### WP-0.2A — Source-linked saturated hydraulic evolution
+WP03-001 completes the planned first-generation extension sequence before a
+validation-led pivot. The limiting issue is no longer whether additional
+equations can be implemented. It is whether competing mechanisms can be
+identified from real espresso observations.
 
-The selected first mechanism is the Waszkiewicz saturated
-dissolution-indexed effective-permeability closure. Its first implementation
-is an optional algebraic effective-permeability branch driven by the locked
-empirical dissolved-mass trajectory. It changes saturated hydraulic
-resistance only and preserves the constant-permeability branch as a regression
-control.
+Compaction, swelling, dissolution-driven porosity, state-dependent
+permeability, concentration-dependent viscosity, fines, damage, and channeling
+can produce overlapping pressure, flow, cup-mass, TDS, extraction, and
+spatial-maldistribution signatures. Adding several such mechanisms without
+intervening data comparison would increase flexibility faster than physical
+identifiability.
 
-The first branch excludes dynamic pore-volume storage, deforming mesh, a full
-stress/displacement solve, swelling, hysteresis, machine/headspace coupling,
-fines, and channeling. Full poroelastic deformation and solver-coupled
-dissolved mass remain later evolving-puck work. Machine/headspace coupling is
-the immediate runner-up if this branch leaves a coherent boundary-history
-residual. No mechanism may be hidden in an arbitrary fitted `K(t)`, and
-development remains one mechanism at a time. Issue #18 is the next milestone;
-this strategy decision implements no governing physics.
+The next program tranche therefore develops source-specific validation
+adapters, uncertainty-aware comparisons, sensitivity and identifiability
+tools, residual decomposition, mechanism discrimination, ensemble execution,
+and experimental design. This is solver development directed at evidence, not
+a pause in solver development.
+
+The next governing-physics increment will be selected from observed residuals
+and information gaps rather than from implementation convenience. General
+physical validation remains `NOT_ESTABLISHED`.
+
+### Completed first-generation extension sequence
+
+WP02-001 through WP02-004 and WP03-001 are complete. They added optional
+dissolution-indexed effective permeability, machine/headspace compliance and
+an emergent basket-pressure operating point, saturated Darcy–Forchheimer
+resistance, static radial flow focusing with zone-resolved extraction, and
+saturated quasi-static compaction.
+
+WP03-001 changes mechanical porosity and permeability under effective stress,
+composes with the machine operating-point calculation, and is inactive during
+wetting. It uses a fixed reference mesh, does not solve solid displacement,
+and does not couple mechanical porosity to transport storage. Transient Biot
+storage, plasticity, hysteresis, swelling, fines, damage, and dynamic
+channeling remain outside that branch.
+
+### Historical Version 1.5 decision
+
+Version 1.5 selected WP02-001 under issue #18 as the first evidence-led WP-0.2
+mechanism and identified machine/headspace coupling as its runner-up. That
+sequence is now historical: WP02-001, machine coupling, Darcy–Forchheimer
+integration, radial heterogeneity, and WP03-001 have all been completed.
 
 Version 1.4 recorded the transition to a clean public solver repository. It changed repository governance, public provenance, CI, licensing documentation, and dependency workflow only. It did not change governing physics, scientific configuration, calibration, numerical schemes, validation thresholds, the scientific roadmap, or the claim ceiling. Exact archival v0.1.4 bytes remain offline; public development begins from the sanitized derivative `v0.1.4-public.1`.
 
@@ -138,7 +162,12 @@ terminal freeze manifest generated last.
 
 The terminal manifest—not intermediate preterminal status text—is the final authority. One benign diagnostic-classifier false positive remains in the finalized run status: the empty JSON member `"failed_comparisons": []` was listed as a detected issue. It does not represent a failed comparison, did not affect any gate, and does not justify mutating or regenerating the frozen baseline. The classifier should be corrected on the next development branch.
 
-WP-0.1H is therefore complete at the implementation, code-verification, numerical-qualification, and immutable-provenance levels. This materially changes the program’s critical path. The next task is not another R0 release and is not immediate addition of attractive multiphysics. It is to preserve and register the qualified baseline, then test the architecture against source-linked evidence.
+### Historical Version 1.5 immediate sequence
+
+The following paragraphs retain the Version 1.5 sequence for chronology. Every
+listed implementation item has since been completed or superseded.
+
+WP-0.1H was complete at the implementation, code-verification, numerical-qualification, and immutable-provenance levels. At that time, this changed the program’s critical path from another R0 release to preserving and registering the qualified baseline and testing the architecture against source-linked evidence.
 
 The immediate program sequence is:
 
@@ -159,6 +188,55 @@ The model program continues to combine four capabilities:
 The controlling development philosophy is now:
 
 > **Preserve the frozen whole-pull baseline, confront it with source-linked evidence, and extend it one mechanism at a time only when a named residual, experiment or engineering decision requires the added physics.**
+
+### Why the validation pivot occurs after WP03-001
+
+The solver now contains independently selectable hydraulic and structural
+hypotheses, and its analytical, regression, conservation, timestep, mesh, and
+MPI evidence is sufficiently mature for real-data confrontation. For the
+tested cases, discretization and solver uncertainty are generally smaller than
+unresolved uncertainty in real permeability, wetting, extraction, machine
+response, structural evolution, and transfer.
+
+The post-WP03-001 bottleneck is therefore an
+`EPISTEMIC_IDENTIFIABILITY_LIMIT`, not a computational or architectural block.
+Compaction, swelling, dissolution-driven porosity change, state-dependent
+permeability, concentration-dependent viscosity, fines deposition or release,
+and damage or channel formation can all contribute to declining flow, changing
+basket pressure, altered cup production, TDS, extraction yield, and spatial
+maldistribution. A model that can fit those observations with several
+alternative mechanisms is not necessarily better identified or more
+predictive.
+
+Unrestricted mechanism accumulation or fitting would promote equifinality
+rather than physical understanding. Validation and mechanism discrimination
+now have greater information value than another immediate physics branch.
+Future physics remains technically possible; evidence will determine which
+branch is load-bearing.
+
+### Program cadence after WP03-001
+
+> **After WP03-001, the program must not add two new evolving-puck
+> governing-physics mechanisms consecutively without an intervening comparison
+> against relevant real espresso evidence.**
+
+This is human program-development guidance. It is not a CI gate, a
+static-validation requirement, a merge blocker, or a new repository-governance
+framework. It does not prohibit numerical corrections, scientific bug fixes,
+source adapters, validation tooling, sensitivity or uncertainty analysis,
+identifiability work, or bounded improvements needed to compare an existing
+model with measured observables.
+
+The operating cadence is:
+
+```text
+verify implementation
+-> compare with evidence
+-> decompose residuals
+-> select one mechanism
+-> implement and verify
+-> return to evidence
+```
 
 ## 1. Why Version 1.3 is a milestone update
 
@@ -219,7 +297,7 @@ The v0.1.4 fresh-package run and terminal manifest establish that the bounded wh
 
 The project therefore has a **frozen and numerically qualified machine-to-cup computational spine** for the declared R0 equations.
 
-### 1.4 What remains unestablished
+### 1.4 What remains unestablished after WP03-001
 
 The completed freeze does not establish:
 
@@ -228,14 +306,14 @@ The completed freeze does not establish:
 - physical validation of first drip, flow, TDS or extraction yield for a protected real-coffee experiment;
 - transfer across coffees, grinders, baskets, machines or recipes;
 - validated swelling, compaction, fines migration, clogging or channeling;
-- full machine/headspace/basket coupling;
+- independent physical validation of machine/headspace/basket coupling;
 - engineering optimization or taste prediction.
 
 The approximately 40 g result remains a calibration-class endpoint because saturated permeability is the declared R0 hydraulic scale parameter. The extraction rate, extractable fraction, effective dispersion and concentration ceiling remain engineering assumptions for WP-0.1.
 
 Immutable provenance strengthens the evidence record; it does not transform a calibrated scenario into independent validation.
 
-### 1.5 Strategic consequence
+### 1.5 Historical strategic consequence at Version 1.3
 
 The program’s critical path has advanced:
 
@@ -259,7 +337,10 @@ The principal risks are now:
 - adding new physics before the first source-linked residual is understood;
 - integrating code into Puckworks without preserving the exact artifact, evidence and validity contracts.
 
-Version 1.3 therefore treats R0 as a protected baseline, WP-0.1R as the next scientific test, and Puckworks registration as a governed integration task rather than a code-copy exercise.
+Version 1.3 therefore treated R0 as a protected baseline and WP-0.1R as the
+next scientific test. That chronology is preserved here as historical context;
+the current active tranche is post-WP03-001 validation and mechanism
+discrimination.
 
 ## 2. Program mission, objectives, and definition of success
 
@@ -819,7 +900,9 @@ Optional inertial extension:
 + \rho_\ell\,\boldsymbol{\beta}_F |\mathbf{u}|\mathbf{u}.
 \]
 
-The executed reference shot uses Darcy flow and should use the Puckworks inertial model as a regime diagnostic before any Forchheimer branch is activated. Forchheimer physics should be activated only when the predicted regime and evidence justify it.
+The frozen R0 reference uses Darcy flow. The current solver also provides the
+completed optional WP02-003 Darcy–Forchheimer branch and its regime
+diagnostics; it remains disabled unless explicitly selected.
 
 ### 5.4 Wetting
 
@@ -953,7 +1036,11 @@ basket or outlet node
 ambient pressure
 ```
 
-R0 prescribes bed-top pressure directly and sets the declared outlet to ambient gauge pressure. Machine delivery, compliance and downstream resistance are intentionally not yet solved as separate coupled components. The machine-coupled mode must use explicit node names and prevent any pressure drop from being counted both in the machine model and porous bed.
+R0 prescribes bed-top pressure directly and sets the declared outlet to
+ambient gauge pressure. The completed WP02-002 branch optionally solves
+machine delivery, compliance, upstream resistance, and emergent basket
+pressure using explicit node names. The prescribed-pressure mode remains the
+frozen regression control.
 
 ### 6.4 Numerical progression and current status
 
@@ -971,10 +1058,11 @@ R0 prescribes bed-top pressure directly and sets the declared outlet to ambient 
 | Serial/rank-count equivalence | COMPLETE | 1/16/32/64 reference and 1/16 layered pass |
 | No-physics freeze finalization | COMPLETE | 28/28 comparison gates and terminal manifest pass |
 | Immutable R0 baseline | **FROZEN / QUALIFIED** | Exact executable, inputs, outputs and qualification bound |
-| Data-linked R1 reconstruction | **NEXT** | Source-specific hydraulic and extraction comparison |
-| Puckworks backend/scenario registration | **NEXT / PARALLEL** | Governed integration of frozen R0 and R1 contracts |
-| Spatial heterogeneity and alternative closures | LATER | Named residual or decision need |
-| Dynamic porosity/permeability | LATER | One mechanism at a time |
+| Data-linked R1 reconstruction | COMPLETE WITH STRUCTURAL RESIDUAL | Source-specific reconstruction; not independent validation |
+| Machine and hydraulic integration | COMPLETE THROUGH WP02-004 | Machine coupling, inertial flow, and static heterogeneity |
+| Quasi-static compaction | COMPLETE THROUGH WP03-001 | Saturated-only, fixed-mesh, no storage coupling |
+| Validation and mechanism discrimination | **ACTIVE** | Source adapters, comparisons, uncertainty, identifiability, residuals |
+| Next evolving-puck mechanism | NOT PRESELECTED | Selected from discriminating evidence |
 | Three-dimensional basket | LATER | Defined non-axisymmetric question |
 
 ### 6.5 Implemented field outputs
@@ -1302,7 +1390,9 @@ Required or relevant fixtures include:
 - Cameron or alternative extraction trajectories;
 - measured tamped-permeability ranges.
 
-**Current status:** not yet established. WP-0.1R is the first source-linked reconstruction milestone.
+**Current status:** source reconstruction is established case-by-case for
+WP01R/WP02/WP03 artifacts. Independent component validation remains to be
+assessed in the active post-WP03-001 tranche.
 
 #### Level V3 — coupled reference shot
 
@@ -1321,7 +1411,9 @@ Assess:
 
 #### Level V4 — independent and intervention holdouts
 
-**Current status:** not started.
+**Current status:** not authorized or started. The current plan prepares
+source-specific comparisons and future holdout requirements without opening
+protected observations.
 
 #### Level V5 — transfer and engineering decisions
 
@@ -1400,152 +1492,102 @@ These ceilings are controlling and must be carried into Puckworks cards, reports
 
 **Status:** **COMPLETE**
 
-Implemented physics:
-
-- initially dry sharp-front wetting;
-- prescribed bed-top pressure ramp to 9 bar;
-- uniform Darcy flow;
-- static porosity and permeability fields;
-- one representative solute;
-- fixed temperature;
-- explicit retained and cup inventories;
-- machine-readable conservation and acceptance reporting.
-
-Outcome:
-
-- a complete machine-to-cup 30 s calculation;
-- corrected first-drip and full-cylinder scaling;
-- all declared run-level gates passed;
-- a stable end-to-end computational spine.
+The reference implementation established dry-puck sharp-front wetting,
+prescribed pressure, uniform Darcy flow, conservative one-solute extraction,
+retained inventories, cup accumulation, and the complete machine-to-cup
+computational spine.
 
 ### Milestone WP-0.1H — Numerical hardening and qualification
 
 **Status:** **COMPLETE — FROZEN / QUALIFIED**
 
-Completed:
-
-- exact straight-sided-wedge scaling;
-- exact pressure-ramp integration;
-- analytical wedge-volume, Darcy-flow and first-drip gates;
-- layered heterogeneous-pressure fixture;
-- selected time-step and mesh qualification matrix;
-- 1/16/32/64-rank equivalence;
-- OpenFOAM/B0 parity;
-- explicit bounded-state and monotonic-inventory gates;
-- automatic timestamp normalization and clean Foundation 12 build;
-- live logging, stage timings and build provenance;
-- standard ten-run `Allverify` campaign with 9/9 aggregate gates passed;
-- terminal immutable release binding through v0.1.4.
-
-WP-0.1H is the protected R0 regression and calibration baseline for all future work.
-
-### Milestone WP-0.1F — Immutable freeze finalization
-
-**Status:** **COMPLETE**
-
-Version 0.1.4 completed with no governing-physics change:
-
-- the case-manifest/acceptance circular dependency was removed;
-- acceptance and run status were finalized after standard `Allverify`;
-- qualification path, hash and PASS status were bound;
-- bounded-state and monotonicity gates were added;
-- 32 ranks became the routine R0 default;
-- the exact compiled executable was archived and reused for qualification;
-- 28/28 no-physics-change comparisons passed;
-- a fresh-package `./Allrun` and standard `./Allverify` passed;
-- the terminal freeze manifest was generated last;
-- R0 was marked `FROZEN / QUALIFIED`.
-
-The complete post-qualification directory must now be archived externally and treated as read-only.
+WP-0.1H completed analytical, reduced-twin, conservation, mesh, timestep, MPI,
+bounded-state, and immutable-provenance qualification. R0 remains the protected
+`FROZEN / QUALIFIED` regression and calibration baseline.
 
 ### Milestone WP-0.1R — Source-linked reference qualification
 
-**Status:** **IMMEDIATE SCIENTIFIC CRITICAL PATH**
+**Status:** **COMPLETE WITH STRUCTURAL RESIDUAL; NOT INDEPENDENT PHYSICAL
+VALIDATION**
 
-Required work:
-
-- refresh the current Puckworks repository and source-data baseline;
-- implement R1 as a distinct Waszkiewicz-linked 18.5 g, 58 mm, 9 bar case;
-- reconstruct source-defined pressure and flow nodes;
-- compare with the relevant Q(t), permeability and poroelastic evidence;
-- compare first-drip and wetting behavior with Foster-informed evidence where compatible;
-- reconstruct one selected extraction source under its own assumptions;
-- state calibration inputs, protected comparison outputs and evidence ceilings before fitting;
-- quantify digitization and source uncertainty;
-- register reduced artifacts, cards, provenance and findings in Puckworks;
-- preserve frozen R0 unchanged as a regression control.
+WP-0.1R reconstructed the source-linked case and exposed structural residuals
+under its declared calibration/comparison contract. It did not establish
+cross-rig transfer or general physical validation.
 
 ### Milestone WP-0.2 — Machine and hydraulic integration
 
-Add only after R1 identifies the most load-bearing hydraulic residual:
+**Status:** **COMPLETE THROUGH WP02-004**
 
-- pump/headspace compliance;
-- explicit machine control profile;
-- measured pressure-node adapters;
-- Darcy/Forchheimer branch;
-- bounded radial/depth heterogeneity;
-- uncertainty in permeability and wetting;
-- a clear pump–bed operating-point solution rather than prescribed bed-top pressure where data support it.
+Completed capabilities are:
 
-### Milestone WP-0.3 — Evolving puck
+- optional dissolution-indexed effective permeability;
+- lumped machine/headspace compliance and upstream resistance;
+- emergent basket pressure;
+- saturated Darcy and Darcy–Forchheimer flow;
+- uniform, axial-layered, and radial two-zone permeability;
+- zone-resolved flow and extraction diagnostics.
 
-Add as separate branches:
+### Milestone WP-0.3 — Initial structural branch
 
-- poroelastic compaction;
+**Status:** **WP03-001 COMPLETE**
+
+WP03-001 implements saturated quasi-static effective stress, mechanical
+porosity, pressure-dependent permeability, the exact finite-porosity
+pressure-flow response, machine coupling, and fixed-reference-mesh deformation
+diagnostics. It does not couple mechanical porosity to transport storage or
+solve full solid mechanics.
+
+### Active milestone — Post-WP03-001 validation and mechanism discrimination
+
+**Status:** **ACTIVE NEXT PROGRAM TRANCHE**
+
+Required outcomes are:
+
+- source-specific validation adapters and evidence classification;
+- explicit calibration/comparison separation;
+- uncertainty-aware metrics and real-data component comparisons;
+- limited coupled comparisons;
+- sensitivity and practical-identifiability assessment;
+- a mechanism-comparison matrix and residual decomposition;
+- ranked next-physics recommendations;
+- targeted experimental requirements.
+
+This tranche is solver development. It builds executable comparison,
+uncertainty, ensemble, and discrimination capability rather than adding an
+immediate new governing equation.
+
+### Later governing-physics candidates
+
+The following remain candidates, not a predetermined queue:
+
+- transient poroelastic storage or fuller deformation;
 - swelling;
-- dissolution-driven porosity change;
+- dissolution-driven porosity;
 - concentration-dependent viscosity;
-- state-dependent permeability.
+- further state-dependent permeability;
+- fines migration and deposition;
+- damage and dynamic channeling;
+- thermal coupling;
+- multispecies chemistry.
 
-Use common observables to compare their effects, and do not hide them inside one generic fitted `K(t)`.
+Their order will be selected from evidence. Later equipment/recipe design and
+an evidence-qualified engineering platform remain program goals.
 
-### Milestone WP-0.4 — Fines and channeling
+### Residual-led decision framework
 
-Add:
+| Observed residual or discriminating evidence | Candidate next physics |
+|---|---|
+| Pressure/flow residual correlated with measured bed compression | Fuller poroelastic deformation or storage |
+| Flow decay correlated with measured particle or bed expansion | Swelling |
+| Flow changes correlated with concentration or viscosity measurements | Concentration-dependent viscosity |
+| Turbidity, captured fines, or deposition evidence | Fines transport |
+| Repeatable localized outlet-flow or extraction defects | Non-axisymmetric channeling or damage |
+| Temperature-correlated hydraulic or extraction residual | Energy equation |
+| Species-specific extraction disagreement | Multispecies chemistry |
+| No discriminating evidence | Retain the simpler model and request better data |
 
-- Eulerian mobile and bound fines inventories;
-- deposition and release;
-- local permeability feedback;
-- optional Lagrangian particles;
-- Taichi-derived capture/clogging closures;
-- non-axisymmetric 3D cases for localization;
-- channel diagnostics rather than an arbitrary binary “channel” flag.
-
-### Milestone WP-0.5 — Thermal and multispecies chemistry
-
-Add:
-
-- transient energy equation;
-- temperature-dependent viscosity and diffusivity;
-- multiple soluble species;
-- size-dependent intraparticle diffusion;
-- partition and equilibrium limits;
-- species-specific cup accumulation;
-- selected gas effects if evidence requires them.
-
-### Milestone WP-0.6 — Equipment and recipe design
-
-Add:
-
-- basket hole field and outlet geometry;
-- bottom paper/filter branches;
-- screen and plenum resistance;
-- pressure/flow/temperature profile design;
-- machine compliance and control;
-- grinder/PSD and dose/tamp sensitivity;
-- surrogate and robust optimization.
-
-### Milestone WP-1.0 — Evidence-qualified engineering platform
-
-A mature release requires:
-
-- protected holdout performance;
-- uncertainty calibration;
-- transfer-domain limits;
-- simple-baseline comparisons;
-- decision-ranking evidence;
-- extrapolation rejection;
-- public reproducibility.
+This table guides scientific investigation; it does not automatically
+authorize a mechanism.
 
 ## 11. Mechanism-specific development rules
 
@@ -1966,7 +2008,9 @@ It does not support:
 - taste prediction;
 - engineering optimization.
 
-Physical-validation claims require WP-0.1R and subsequent protected holdouts.
+Physical-validation claims require appropriately independent component,
+coupled, cross-condition or separately authorized holdout evidence. WP-0.1R
+alone is a source-linked reconstruction and cannot establish them.
 
 ### 14.6 Required frozen output set
 
@@ -2021,7 +2065,8 @@ New data should be requested because a named parameter, closure or competing mec
 
 ### 15.2 Use current Puckworks evidence first
 
-The next source-linked work should use and compare with the repository’s available:
+The active validation tranche should use and compare with the repository’s
+rights-reviewed evidence inventory:
 
 - 9-bar flow traces and pressure–flow calibration;
 - CT infiltration and first-drip evidence;
@@ -2033,11 +2078,15 @@ The next source-linked work should use and compare with the repository’s avail
 - fines and dynamic-flow signatures;
 - liquor property data.
 
-The repository baseline must be refreshed before integration so newer model cards, data, rights records and whole-pull-related work are not missed.
+The recorded dependency lock must not be advanced except by a separately
+authorized dependency review. Each adapter must preserve the applicable model
+card, data identity, rights status, pressure node, quantity definition and
+uncertainty.
 
-### 15.3 R1 as the first data-linked reconstruction
+### 15.3 Historical R1 reconstruction
 
-R1 should be built as a source-specific case rather than by relabelling R0. It must declare:
+R1 was built as a source-specific case rather than by relabelling R0. Its
+lessons remain controlling:
 
 - the 18.5 g dose and rig geometry;
 - coffee and grind descriptors where available;
@@ -2048,7 +2097,9 @@ R1 should be built as a source-specific case rather than by relabelling R0. It m
 - which observations are used for calibration;
 - which features remain comparison or holdout targets.
 
-R1 is the first opportunity to test whether the qualified baseline hydraulic architecture reproduces source-linked dynamics beyond the calibrated R0 endpoint.
+R1 demonstrated why source reconstruction, calibration and independent
+comparison must remain distinct. Its protected flow-shape residual is
+historical evidence, not authorization to reopen protected scoring.
 
 ### 15.4 Extraction evidence priority
 
@@ -2160,81 +2211,56 @@ Remaining operational task:
 
 ### Phase E — Data-linked R1 and Puckworks integration
 
-**Status:** immediate critical path.
+**Status:** complete with a structural residual; not independent physical
+validation.
 
-Implement:
+### Phase F — Hydraulic and first structural expansion
 
-- refreshed Puckworks repository and evidence review;
-- R1 18.5 g / 58 mm / 9 bar source-specific case;
-- Waszkiewicz-linked pressure and flow comparisons;
-- Foster-linked wetting comparison where compatible;
-- one selected extraction-source reconstruction;
-- predeclared calibration and holdout ledger;
-- component/backend card;
-- R0 and R1 scenario/state adapters;
-- source and data bindings;
-- validation and validity gates;
-- CLI/API entry point;
-- novice-facing local run guide;
-- immutable links to external R0 field artifacts.
+**Status:** complete through WP03-001.
 
-### Phase F — Hydraulic and machine expansion
+WP02-001 through WP02-004 added independently selectable effective-
+permeability evolution, machine compliance, inertial resistance and static
+radial heterogeneity. WP03-001 added saturated quasi-static compaction.
 
-Proceed to WP-0.2 only after R1 exposes the most important hydraulic residuals. Add machine pressure nodes, compliance, flow control, inertial diagnostics or bounded heterogeneity according to the evidence.
+### Phase G — Validation and mechanism discrimination
 
-### Phase G — Dynamic and multiscale upgrades
+**Status:** active next program tranche.
 
-Proceed in the milestone order defined in Section 10. Select each new physics branch by sensitivity, evidence and its ability to improve a named holdout or engineering decision.
+Implement source-specific adapters, rights- and evidence-aware comparison
+bundles, uncertainty propagation, sensitivity and identifiability analysis,
+residual decomposition, mechanism comparisons and experiment-design
+priorities. Compare existing branches before selecting one next
+governing-physics increment.
+
+### Phase H — Evidence-selected physics
+
+Resume governing-physics expansion only when the validation residuals and
+available measurements identify a load-bearing mechanism. Candidate work
+includes fuller poroelastic storage, swelling, viscosity, fines, localized
+damage, thermal coupling and multispecies chemistry; this list is not a queue.
 
 ## 17. Immediate next actions
 
-The following sequence is controlling.
+The following sequence is controlling:
 
-### Seal and preserve the frozen v0.1.4 baseline
+1. implement the common source-adapter and calibration/comparison ledger;
+2. inventory admissible evidence, definitions, rights, uncertainties and
+   circularity from the existing lock;
+3. perform one wetting or first-drip component comparison;
+4. perform one saturated hydraulic and one limited coupled pressure/flow
+   comparison;
+5. perform one aggregate extraction comparison while preserving the
+   one-solute limitation;
+6. propagate supported uncertainties and assess parameter sensitivity,
+   correlation, equifinality and practical identifiability;
+7. compare compatible existing mechanisms on common source-specific cases;
+8. decompose residuals by pressure, time, space, apparatus and observable;
+9. rank missing measurements by expected information value; and
+10. recommend either the simpler existing family, one evidence-supported next
+    mechanism, or additional data.
 
-1. **Do not run `./Allclean` on the only successful post-qualification directory.** Preserve the reconstructed fields, exact archived executable, fixture outputs, individual qualification cases, logs and terminal manifest.
-2. **Create a complete immutable external archive.** Package the entire post-`Allverify` directory as a versioned `tar.gz` or equivalent and calculate an external SHA-256.
-3. **Store at least two durable copies.** Keep one local archival copy and one independent backup; record the paths, archive size and checksum.
-4. **Record the terminal-manifest identity in Puckworks.** Bind the v0.1.4 terminal-manifest path, source aggregate, solver hash, field aggregate and controlling-artifact aggregate.
-5. **Treat v0.1.4 as read-only evidence.** Future work starts from a clean source package or new branch and never rewrites the frozen artifacts.
-
-### Complete the frozen-baseline documentation
-
-6. **Issue the formal R0 reference specification.** Document exact equations, units, nodes, inputs, calibration role, numerical settings, gates, artifacts and claim ceiling.
-7. **Publish a concise WP-0.1H result note.** Explain what passed, the frozen outputs, the qualification matrix, the calibration/validation distinction and the next scientific question.
-8. **Document the one residual classifier defect.** Record that `"failed_comparisons": []` is a benign false positive; fix the classifier in the next development version without regenerating v0.1.4.
-9. **Create a frozen-baseline regression fixture.** Store reduced scalar outputs and hashes that future branches can compare against without needing every full field file in routine CI.
-
-### Refresh Puckworks before source-linked implementation
-
-10. **Review current Puckworks `main`.** Refresh the inherited `d9ee264` baseline and identify all relevant model cards, data assets, rights records, source extractions, quantity definitions and recent whole-pull work.
-11. **Define registration IDs and repository paths before copying code.** Avoid creating parallel contracts or duplicate quantity semantics.
-12. **Create a rights-and-evidence ledger for WP-0.1R.** State what can be redistributed, what may be locally derived, and what must remain citation-only or private.
-
-### Build the WP-0.1R evidence dossier
-
-13. **Freeze the exact source corpus.** Record paper/version identifiers, supplementary files, tables, figures and any digitized traces used.
-14. **Define the physical apparatus and pressure nodes.** Resolve basket geometry, 18.5 g dose, coffee/grind descriptors, pressure measurement location, outlet resistance and ambient reference.
-15. **Extract the 9-bar hydraulic observations with uncertainty.** Preserve raw digitization points, transformations, units, interpolation policy and trace uncertainty.
-16. **Predeclare calibration and comparison roles.** Name the smallest permitted calibration set and reserve independent trace features, pressure levels or other runs for comparison/holdout.
-17. **Construct an R1 scenario contract.** Make every R0-to-R1 change explicit; do not edit R0 into a fictitious measured case.
-18. **Define R1 acceptance before running it.** Include execution, conservation, numerical regression, source-node consistency, calibration reporting and unforced comparison metrics.
-
-### Implement and evaluate R1
-
-19. **Create a separate versioned OpenFOAM case and reduced-twin configuration.** Reuse frozen R0 solver logic initially unless source evidence requires a declared new branch.
-20. **Run a source-equivalent hydraulic reconstruction first.** Compare Q(t), pressure behavior and selected permeability/poroelastic quantities before adding chemistry complexity.
-21. **Diagnose residuals by class.** Separate source uncertainty, node mismatch, calibration limitation, numerical error and model-form error.
-22. **Reconstruct one extraction source explicitly.** Use the same hydraulic history to compare at least one alternative closure and expose chemistry sensitivity.
-23. **Do not consume every source observation in fitting.** Preserve protected features or conditions for meaningful evaluation.
-
-### Integrate with Puckworks and select the next physics
-
-24. **Register the frozen R0 backend and scenario.** Add component cards, validity claims, reduced fixtures, terminal-manifest identity and external artifact links.
-25. **Register R1 as a distinct source-linked scenario.** Include its source ledger, calibration/holdout split and comparison report.
-26. **Use the R1 residual hierarchy to select WP-0.2.** Likely candidates include machine/headspace coupling, pressure-dependent permeability, poroelasticity or bounded heterogeneity.
-27. **Add no mechanism merely because OpenFOAM can solve it.** Fines, channeling, multispecies chemistry, dynamic geometry and heat transfer require a named residual, closure request, experiment or engineering decision.
-28. **Begin the formal literature/capability benchmark in parallel.** Compare the program with published espresso SPH, LBM, continuum and extraction models before making public superlative claims.
+No validation execution, protected access, holdout opening, fitting or
+experimental commissioning is authorized by this strategy update.
 
 ## 18. Program risks and controls
 
@@ -2250,7 +2276,7 @@ The following sequence is controlling.
 | Digitized traces are treated as exact data | Overconfident calibration and residual interpretation | Preserve raw points, digitization method and uncertainty bounds |
 | Puckworks integration uses a stale repository baseline | Duplicate contracts or missed evidence | Refresh current `main`, cards, data and rights before integration |
 | Integration becomes only a code dump | New solver loses evidence discipline | Require backend cards, scenario contracts, validity gates, reduced fixtures and immutable artifact links |
-| New physics is added before R1 identifies a load-bearing residual | Regression causes become difficult to identify | Keep R0 frozen and make WP-0.1R the next scientific gate |
+| New mechanisms accumulate without evidence comparison | Flexibility and equifinality increase faster than physical identification | Apply the post-WP03-001 cadence rule and select one next mechanism from residual evidence |
 | Bounded sensitivity is described as formal order of convergence | Numerical evidence is overstated | Report tested differences and thresholds; do not claim asymptotic order without a dedicated study |
 | All 64 ranks are used by default | Slower routine R0 runs and wasted resources | Use 32 ranks for the reference mesh and 64 for the fine mesh unless new scaling evidence changes the policy |
 | Retained dissolved solute sensitivity is ignored | Future in-puck chemistry claims may be under-resolved | Revisit mesh qualification when chemistry or retained-state detail becomes decision-critical |
@@ -2296,29 +2322,36 @@ The following sequence is controlling.
 
 ---
 
-## 20. Version 1.3 controlling summary
+## 20. Version 1.6 controlling summary
 
-The Puckworks modeling and simulation program now has a frozen, numerically qualified whole-process espresso reference solver.
+The program has a frozen, numerically qualified R0 and a modular Foundation
+OpenFOAM 12 whole-pull solver. WP01R and WP02-001 through WP02-004 added
+source-linked reconstruction, effective-permeability evolution, machine
+compliance, Darcy–Forchheimer resistance and static spatial heterogeneity.
+WP03-001 added saturated quasi-static compaction with pressure-dependent
+mechanical porosity and permeability on a fixed reference mesh.
 
-The v0.1.4 Foundation OpenFOAM 12 package completed a fresh 32-rank R0 run, exact-build reuse verification, a heterogeneous layered-pressure fixture, the standard ten-run time-step/mesh/MPI qualification campaign, post-qualification finalization and terminal provenance generation. All required run gates, bounded-state gates, monotonicity gates, OpenFOAM/B0 parity gates, 28 no-physics-change comparisons, ten individual qualification acceptances and nine aggregate qualification gates passed.
+Those branches are numerically verified for their tested domains. They do not
+establish physical validation. In particular, WP03-001 does not solve solid
+displacement, couple mechanical porosity to transport storage, or include
+transient Biot storage, plasticity, hysteresis, swelling, fines, damage or
+dynamic channeling.
 
-The frozen R0 result is approximately 40.958 g beverage at 30 s, first drip at 4.7117 s, final flow at 1.48268 mL/s, TDS at 11.689% and extraction yield at 23.938%. Liquid and solute balances close near machine precision, all expected fields are reconstructed, and rank-count differences are negligible across 1, 16, 32 and 64 ranks.
-
-The terminal manifest binds 106 source files, 19 scientific-input files, the exact compiled and portable solver executable, 339 reconstructed field files, all ten qualification acceptances and 20 controlling artifacts. The final disposition is:
+The active milestone is now:
 
 ```text
-WP-0.1 implementation             PASS
-WP-0.1 code verification          PASS
-WP-0.1 numerical qualification    PASS
-WP-0.1 release provenance         PASS
-WP-0.1H / R0 status               FROZEN / QUALIFIED
-physical validation               NOT ESTABLISHED
-next scientific milestone         WP-0.1R
+completed solver sequence          WP-0.1 through WP03-001
+active program tranche             source-specific validation and mechanism discrimination
+next governing physics             not preselected; residual-led
+physical validation                NOT ESTABLISHED
+experimental commissioning         NOT AUTHORIZED
+protected or holdout scoring       NOT AUTHORIZED
 ```
 
-The frozen result remains a bounded calibration scenario. Saturated permeability sets the R0 hydraulic scale, and the one-solute extraction closure remains an engineering assumption. Immutable provenance does not turn the approximately 40 g endpoint, first drip, TDS or extraction yield into independent real-coffee validation.
-
-The immediate operational action is to archive the complete post-`Allverify` directory and register its terminal-manifest and external archive identities. The immediate scientific action is WP-0.1R: a distinct source-linked 18.5 g, 58 mm, 9 bar reconstruction, followed by formal Puckworks registration and evidence-selected physics expansion.
+The frozen R0 remains a bounded calibration scenario, and source or post-fit
+reconstruction remains distinct from independent validation. The validation
+tranche will build executable adapters and comparisons, quantify uncertainty
+and identifiability, and determine which residuals justify one next mechanism.
 
 The defining architecture remains:
 
@@ -2334,7 +2367,9 @@ reduced verification and decision models.
 
 The controlling rule is now:
 
-> **Protect the frozen baseline, test it against source-linked evidence, and add new physics only when the evidence identifies a load-bearing residual or engineering need.**
+> **Protect the frozen baseline, compare the existing model family with
+> relevant real evidence, decompose residuals, and add one next mechanism only
+> when the evidence identifies a load-bearing residual or engineering need.**
 
 ## Appendix A — Controlling evidence from completed work
 

--- a/docs/validation/POST_WP03_001_VALIDATION_AND_MECHANISM_DISCRIMINATION_PLAN.md
+++ b/docs/validation/POST_WP03_001_VALIDATION_AND_MECHANISM_DISCRIMINATION_PLAN.md
@@ -1,0 +1,287 @@
+# Post-WP03-001 Validation and Mechanism-Discrimination Plan
+
+## 1. Objective and authority boundary
+
+> Test the existing modular solver family against real espresso evidence,
+> determine which components explain which observations, quantify uncertainty
+> and non-identifiability, and use the residuals to select the next
+> governing-physics increment.
+
+This is an action plan, not authorization for protected-data access, holdout
+opening, physical experimentation, apparatus commissioning, parameter fitting
+or validation-status promotion.
+
+WP03-001 is the appropriate starting point because machine and hydraulic
+integration, static spatial heterogeneity and a first explicit mechanical
+response are now implemented. Additional mechanisms increasingly compete to
+explain the same pressure, flow, cup and spatial observations. Comparison now
+has greater information value than another immediate mechanism.
+
+## 2. Evidence ladder
+
+- **Level 0 — Numerical verification.** Agreement with analytical,
+  manufactured, regression, conservation and refinement references. This is
+  already extensive.
+- **Level 1 — Source reconstruction.** Reproduction of a source equation,
+  fitted curve or case under its assumptions. This is not independent physical
+  validation.
+- **Level 2 — Independent component comparison.** A component prediction is
+  compared with a real observation not used to determine that output, such as
+  first drip, wetting-front position, steady flow, permeability, basket
+  pressure or cup TDS.
+- **Level 3 — Limited coupled within-apparatus comparison.** Several
+  synchronized outputs from one apparatus are compared. The result remains
+  apparatus- and source-specific.
+- **Level 4 — Cross-condition or out-of-fit comparison.** A fixed model is
+  tested against a materially different coffee, grind, basket, machine,
+  pressure or recipe.
+- **Level 5 — Preregistered holdout and transfer.** Future separately
+  authorized work using unopened observations and predeclared gates. This plan
+  does not authorize Level 5 execution.
+
+Every result must name one evidence class:
+
+```text
+CODE_VERIFICATION
+SOURCE_RECONSTRUCTION
+POST_FIT_RECONSTRUCTION
+WITHIN_RIG_COMPARISON
+INDEPENDENT_COMPONENT_COMPARISON
+CROSS_CONDITION_COMPARISON
+HOLDOUT_INDEPENDENT
+MECHANISM_DISCRIMINATION
+TRANSFER_ASSESSMENT
+```
+
+The word “validated” is insufficient without a named level, component and
+scope.
+
+## 3. Source-specific validation adapter contract
+
+Each adapter must provide:
+
+```text
+adapter_id
+source_id
+source_citation
+evidence_level
+rights_status
+redistribution_status
+apparatus_id
+coffee_id
+grinder_id
+basket_geometry
+dose
+bed_depth
+water_properties
+temperature
+pressure_node_definitions
+flow_definition
+mass_definition
+first_drip_definition
+TDS_method
+EY_method
+source_timebase
+calibration_inputs
+fitted_parameters
+comparison_outputs
+excluded_outputs
+holdout_status
+uncertainty
+known_circularity
+solver_configuration_mapping
+output_mapping
+claim_ceiling
+```
+
+Units and source definitions must be preserved exactly. R0 must not be
+relabeled to imitate another apparatus, and missing values must remain
+explicitly unavailable rather than invented.
+
+Parameters must be classified as `SOURCE_MEASURED`, `SOURCE_DERIVED`,
+`SOURCE_FITTED`, `CROSS_SOURCE_PRIOR`, `SYNTHETIC_FIXTURE`,
+`FIXED_PREDECESSOR_VALUE`, `CALIBRATED_IN_THIS_CASE`, or `UNRESOLVED`.
+Calibration parameters, comparison outputs, independent outputs and excluded
+outputs must be listed separately. A comparison output cannot silently become
+a calibration input.
+
+## 4. Existing evidence inventory
+
+The candidate inventory below is planning metadata derived from the existing
+locked Puckworks integration and retained WP-0.3A review. It does not advance
+the runtime dependency lock or copy restricted source series.
+
+| Candidate | Target | Available / missing evidence | Class, rights and circularity | Suitability and action |
+|---|---|---|---|---|
+| Foster CT infiltration material | Wetting and first drip | Digitized/fitted timing context; source-definition and uncertainty limits remain | Source reconstruction; rights remain artifact-specific; fit circularity | Use only with explicit timing reconciliation and uncertainty; not a hydraulic holdout |
+| Waszkiewicz pressure/flow and compaction material | Hydraulics and quasi-static compaction | Geometry, fitted curve and public pressure points; independent deformation/transfer data remain incomplete | Post-fit or within-rig comparison; CC-BY source material; soft circularity | Reconstruct pinned definitions, then reserve any admissible out-of-fit condition |
+| Gagne DE1 material | Machine and whole-shot hydraulics | Telemetry context; geometry, uncertainty, definitions and redistribution gaps remain | Exploratory within-rig candidate; rights incomplete | Do not qualify until apparatus, node, uncertainty and rights gaps close |
+| Schmieder, Angeloni and Perticarini extraction evidence | Aggregate chemistry | TDS/EY or endpoint context; hydraulic histories and method compatibility vary | Source-specific chemistry evidence; not hydraulic validation | Select only after method and hydraulic-history reconciliation |
+| Moroney, Matias and Liang references | Extraction mathematics and observables | Non-protected mathematical or method-explicit references | Code verification / source reconstruction | Retain as verification support, not physical validation |
+| Vaca Guerra material | Prior information | Inactive offline prior only | Rights/evidence constrained | Do not activate without separate review |
+| Spatial evidence candidates | Radial flow and extraction | Currently incomplete spatial flow, depletion and uncertainty | Exploratory; potentially restricted | Request segmented flow, local chemistry, imaging and post-shot depletion |
+
+The exact Puckworks experimental campaigns retained for planning are:
+
+| ID | Exact campaign name | Validation relevance |
+|---|---|---|
+| EXP-001 | Synchronized whole-shot telemetry and cup chemistry | Coupled hydraulics and chemistry |
+| EXP-002 | Initially dry puck infiltration and physical first drip | Wetting and first drip |
+| EXP-003 | Grinder-specific particle-size, packing, and permeability map | Hydraulic inputs and transfer |
+| EXP-004 | Poroelastic deformation, pressure, and flow | Compaction discrimination |
+| EXP-005 | Time-dependent bed-mechanism discrimination (kappa(t)) | Evolving-mechanism discrimination |
+| EXP-006 | Species-resolved fractional extraction | One-solute limitation and chemistry |
+| EXP-007 | Spatial flow/channeling and local extraction | Spatial maldistribution |
+| EXP-008 | Cross-machine, cross-grinder, cross-coffee replication | Transfer |
+| EXP-009 | Bottom filter-paper mechanism study | Boundary/mechanism isolation |
+
+Campaign preparation is permitted only as planning. Commissioning and
+acquisition require separate authority.
+
+## 5. First validation tranche
+
+### Workstream A — Validation framework
+
+Deliver a source-adapter schema and validator, common comparison-run
+specification, calibration/comparison ledger, uncertainty-aware metric
+library, machine-readable result bundle, standard report template and explicit
+evidence-level output.
+
+The recommended first implementation package is:
+
+```text
+VAL-001 — Source-specific validation adapter framework
+and first component comparisons
+```
+
+Repository naming conventions may refine the identifier.
+
+### Workstream B — Wetting and hydraulics
+
+Deliver one first-drip comparison, one wetting-front or saturation-progression
+comparison where suitable, one steady pressure–flow comparison, one
+permeability comparison, and one machine pressure-node comparison where source
+definitions permit.
+
+### Workstream C — Extraction
+
+Deliver one selected source reconstruction, one out-of-fit aggregate TDS or
+extraction-yield comparison, and sensitivity to extractable fraction,
+mass-transfer rate, dispersion and concentration ceiling. State the current
+one-solute limitation explicitly.
+
+### Workstream D — Mechanism discrimination
+
+Run compatible constant-permeability, dissolution-indexed permeability,
+machine-compliance, Darcy–Forchheimer, static-radial and quasi-static-
+compaction branches on common source-specific cases. Compare first drip,
+upstream and basket pressure, instantaneous and cumulative flow, cup mass,
+TDS, extraction yield, predicted deformation and spatial extraction where
+available.
+
+Do not select the lowest fitted error after unrestricted retuning. Assess
+residual shape, pressure/time/spatial dependence, parameter correlation,
+identifiability, equifinality and transfer.
+
+### Workstream E — Experimental design
+
+Rank future measurements by expected information value, covering synchronized
+telemetry and chemistry, wetting, PSD/packing/permeability, deformation,
+time-dependent mechanisms, spatial flow/extraction, species-resolved
+extraction and cross-apparatus transfer. No experiment is authorized here.
+
+## 6. Initial comparison priorities
+
+1. **Wetting and first drip:** reconcile definitions; report observed and
+   predicted timing, front history where available, uncertainty, residual
+   shape and claim ceiling.
+2. **Saturated hydraulics and permeability:** report pressure, flow, geometry,
+   permeability role, pressure nodes, justified Darcy/Forchheimer/compaction
+   comparisons, uncertainty and residuals.
+3. **Machine-coupled pressure and flow:** test emergent basket pressure,
+   compliance and upstream resistance with synchronized nodes.
+4. **Aggregate extraction:** follow hydraulic-history assessment and preserve
+   the one-solute limitation.
+5. **Spatial maldistribution:** begin with qualitative or bounded comparison
+   until spatial observations and uncertainties are adequate.
+
+## 7. Mechanism-discrimination matrix
+
+The executable tranche must maintain a matrix whose observation rows include
+first drip, wetting progression, basket/upstream pressure, pressure-flow
+nonlinearity, early/late flow, flow-decay shape, cumulative water, cup mass,
+TDS, extraction yield, bed-height change, spatial flow/extraction splits,
+temperature dependence and turbidity/fines evidence.
+
+Columns must include constant permeability, machine compliance,
+dissolution-indexed permeability, Darcy–Forchheimer resistance, static radial
+heterogeneity, quasi-static compaction, and unresolved swelling, viscosity,
+fines and damage/channeling. Each entry records expected signature, current
+solver capability, available evidence, discriminating strength, confounders
+and missing measurements.
+
+## 8. Uncertainty and identifiability
+
+Assess source digitization, sensor and timing-definition uncertainty; dose and
+geometry uncertainty; permeability, wetting, extraction and
+machine-compliance uncertainty; parameter correlation; practical
+identifiability; output sensitivity; and residual correlation. Use uncertainty
+bands only when supported. Otherwise record:
+
+```text
+SOURCE_UNCERTAINTY_NOT_REPORTED
+```
+
+## 9. Residual-led next-physics decision
+
+The tranche must end with one of:
+
+```text
+EXISTING_MODEL_FAMILY_SUFFICIENT_FOR_CURRENT_EVIDENCE
+FULLER_POROELASTIC_STORAGE_JUSTIFIED
+SWELLING_BRANCH_JUSTIFIED
+VISCOSITY_BRANCH_JUSTIFIED
+FINES_TRANSPORT_JUSTIFIED
+NONAXISYMMETRIC_CHANNELING_JUSTIFIED
+THERMAL_BRANCH_JUSTIFIED
+MULTISPECIES_BRANCH_JUSTIFIED
+ADDITIONAL_DATA_REQUIRED_BEFORE_NEW_PHYSICS
+```
+
+The rationale must use residuals, identifiability, cross-condition behavior,
+uncertainty, information value and model complexity. It may not use
+`NEW_PHYSICS_JUSTIFIED_BECAUSE_IMPLEMENTABLE`.
+
+## 10. Exit criteria and retained outputs
+
+The first tranche is complete after it produces a working adapter framework;
+evidence/rights inventory; one wetting or first-drip, saturated hydraulic,
+limited coupled pressure/flow and aggregate extraction comparison; explicit
+calibration/comparison separation; uncertainty-aware metrics; sensitivity and
+identifiability results; a mechanism matrix; ranked experimental-data request;
+and a residual-led recommendation for one next physics increment.
+
+Retain immutable input mappings, ledgers, traces, uncertainty-aware metrics,
+residual plots, sensitivities, identifiability findings, mechanism matrix,
+ranked data gaps and the recommendation. Universal validation and completion
+of every campaign are not required.
+
+## 11. Claim boundary
+
+Every result must report numerical verification, source reconstruction,
+component comparison, limited coupled comparison, cross-condition comparison,
+holdout status and transfer status separately.
+
+```text
+GENERAL_WHOLE_SOLVER_PHYSICAL_VALIDATION:
+  NOT_ESTABLISHED
+
+HOLDOUT_EXECUTION:
+  NOT_AUTHORIZED_BY_THIS_PLAN
+
+EXPERIMENTAL_COMMISSIONING:
+  NOT_AUTHORIZED_BY_THIS_PLAN
+```
+
+A component may receive a bounded comparison status without promoting the
+whole solver.

--- a/scripts/generate_source_manifest.py
+++ b/scripts/generate_source_manifest.py
@@ -58,7 +58,9 @@ PUBLIC_DOCUMENTATION_PATHS = {
     "docs/wp02/WP02_001_EFFECTIVE_PERMEABILITY_BRANCH.md",
     "docs/decisions/ADR-0001-PUBLIC_REPOSITORY_TRANSITION.md",
     "docs/strategy/WHOLE_PULL_MODELING_AND_SIMULATION_STRATEGY.md",
+    "docs/strategy/SOLVER_DEVELOPMENT_AND_VALIDATION_ROADMAP.md",
     "docs/strategy/history/espresso_puck_modeling_and_simulation_strategy_v1_3.md",
+    "docs/validation/POST_WP03_001_VALIDATION_AND_MECHANISM_DISCRIMINATION_PLAN.md",
 }
 
 

--- a/scripts/verify_wp03c_stage0_scaffold.py
+++ b/scripts/verify_wp03c_stage0_scaffold.py
@@ -111,6 +111,17 @@ EXPECTED_PATHS = frozenset({
     "validation/wp03/WP03_001_POROELASTIC_COMPACTION_RUN_SPEC.sha256",
     "validation/wp03/WP03_001_POROELASTIC_COMPACTION_TRACE.csv",
     "validation/wp03/WP03_001_SOURCE_PRESSURE_SWEEP.csv",
+    # Exact later post-WP03-001 documentation-alignment paths. This preserves
+    # the frozen Stage-0 artifact checks while allowing current navigation,
+    # strategy, roadmap, and validation planning to evolve.
+    "README.md",
+    "docs/FILE_TREE.md",
+    "docs/ONBOARDING.md",
+    "docs/PUCKWORKS_INTEGRATION.md",
+    "docs/strategy/SOLVER_DEVELOPMENT_AND_VALIDATION_ROADMAP.md",
+    "docs/strategy/WHOLE_PULL_MODELING_AND_SIMULATION_STRATEGY.md",
+    "docs/validation/POST_WP03_001_VALIDATION_AND_MECHANISM_DISCRIMINATION_PLAN.md",
+    "tests/test_reference_case.py",
 })
 LATER_WP02_002_PATHS = frozenset({
     "docs/reports/WP02_002_MACHINE_PUCK_COUPLING_RESULTS.md",
@@ -175,6 +186,14 @@ LATER_WP02_002_PATHS = frozenset({
     "validation/wp03/WP03_001_POROELASTIC_COMPACTION_RUN_SPEC.sha256",
     "validation/wp03/WP03_001_POROELASTIC_COMPACTION_TRACE.csv",
     "validation/wp03/WP03_001_SOURCE_PRESSURE_SWEEP.csv",
+    "README.md",
+    "docs/FILE_TREE.md",
+    "docs/ONBOARDING.md",
+    "docs/PUCKWORKS_INTEGRATION.md",
+    "docs/strategy/SOLVER_DEVELOPMENT_AND_VALIDATION_ROADMAP.md",
+    "docs/strategy/WHOLE_PULL_MODELING_AND_SIMULATION_STRATEGY.md",
+    "docs/validation/POST_WP03_001_VALIDATION_AND_MECHANISM_DISCRIMINATION_PLAN.md",
+    "tests/test_reference_case.py",
 })
 FROZEN = {
     "validation/wp02/WP02_001_VERIFICATION_AND_RESULTS.json":

--- a/tests/test_reference_case.py
+++ b/tests/test_reference_case.py
@@ -1318,11 +1318,8 @@ class WP01R006DecisionTests(unittest.TestCase):
         strategy = (
             ROOT / "docs/strategy/WHOLE_PULL_MODELING_AND_SIMULATION_STRATEGY.md"
         ).read_text(encoding="utf-8")
-        self.assertIn("**Strategy version:** 1.5", strategy)
+        self.assertIn("**Strategy version:** 1.6", strategy)
         current_header = strategy.split("---", 1)[0]
-        current_sequence = strategy.split(
-            "The immediate program sequence is:", 1
-        )[1].split("The model program continues", 1)[0]
         self.assertIn(
             "fc61c4670ec7bf801e40bb391aab16048b8da26b",
             current_header,
@@ -1335,9 +1332,13 @@ class WP01R006DecisionTests(unittest.TestCase):
             "alignment must be refreshed before integration",
             current_header,
         )
-        self.assertIn("issue #18", current_sequence)
-        self.assertNotIn("construct a source-and-quantity dossier", current_sequence)
-        self.assertNotIn("implement the Waszkiewicz-linked", current_sequence)
+        self.assertIn(
+            "Post-WP03-001 source-specific validation and mechanism discrimination",
+            current_header,
+        )
+        self.assertIn("issue #18", strategy)
+        self.assertIn("ACTIVE NEXT PROGRAM TRANCHE", strategy)
+        self.assertIn("EPISTEMIC_IDENTIFIABILITY_LIMIT", strategy)
         self.assertIn("historical", strategy.lower())
         boundary = self.decision["authorization_boundaries"]
         self.assertFalse(boundary["governing_physics_change"])


### PR DESCRIPTION
This documentation-only change records completion of WP03-001 and activates the planned post-WP03 validation and mechanism-discrimination tranche.

It updates the controlling strategy, concise roadmap, current project state, Puckworks integration, development history, and validation action plan.

It changes no solver code, governing physics, scientific configuration, retained numerical result, dependency lock, validation threshold, or claim ceiling.

The active development cadence is:

    compare the current model family with real evidence
    -> quantify uncertainty and identifiability
    -> decompose residuals
    -> select one next governing-physics increment
    -> implement and verify
    -> return to evidence