### PR TITLE
VAL-DATA-001: design synchronized hydraulic-compaction measurement package

### DIFF
--- a/PACKAGE_QA_STATUS.json
+++ b/PACKAGE_QA_STATUS.json
@@ -30,7 +30,7 @@
     "val001_synthetic_test_count": 58,
     "static_gate_count": 38,
     "source_manifest_file_count": 226,
-    "source_manifest_aggregate_sha256": "9fb273d9187c5946352b3f7104247dc483cfa38e417c22fd262fa3fe53b8ff5a",
+    "source_manifest_aggregate_sha256": "77cdb78efee5b7addd0e10f955106051e120dab95f7d37c52bde5a22994bb7dd",
     "historical_baseline_integrity": "PASS",
     "active_governing_change_contract": "PASS",
     "release_integrity": "PASS",
@@ -77,7 +77,9 @@
     "physical_validation": "NOT_ESTABLISHED",
     "governing_physics_change": "NONE",
     "next_scientific_gate": "ADDITIONAL_INDEPENDENT_DATA_REQUIRED",
-    "machine_mode_campaign_gap": "PUCKWORKS_MACHINE_MODE_CAMPAIGN_GAP"
+    "machine_mode_campaign_gap": "PUCKWORKS_MACHINE_MODE_CAMPAIGN_GAP",
+    "review_status": "CORRECTED_PENDING_EXACT_HEAD_REVIEW",
+    "future_evidence_route": "HUMAN_OWNER_PROSPECTIVE_SELECTION_REQUIRED"
   },
   "val_infra_002": {
     "change_declaration": "NO_GOVERNING_PHYSICS_CHANGE",

--- a/PACKAGE_QA_STATUS.json
+++ b/PACKAGE_QA_STATUS.json
@@ -29,8 +29,8 @@
     "python_test_count": 324,
     "val001_synthetic_test_count": 58,
     "static_gate_count": 38,
-    "source_manifest_file_count": 225,
-    "source_manifest_aggregate_sha256": "38012831244266d74cf7374d07737c5c159354f5382763b16255deb4c18866cf",
+    "source_manifest_file_count": 226,
+    "source_manifest_aggregate_sha256": "9fb273d9187c5946352b3f7104247dc483cfa38e417c22fd262fa3fe53b8ff5a",
     "historical_baseline_integrity": "PASS",
     "active_governing_change_contract": "PASS",
     "release_integrity": "PASS",
@@ -66,6 +66,18 @@
     "val_case_002": "NOT_STARTED",
     "new_openfoam_launches_authorized": 0,
     "physical_validation": "NOT_ESTABLISHED"
+  },
+  "val_data_001": {
+    "task_class": "EXPERIMENTAL_DESIGN_AND_DATA_REQUEST_PLANNING",
+    "change_declaration": "NO_GOVERNING_PHYSICS_CHANGE",
+    "active_validation_case": "NONE",
+    "active_data_planning_task": "VAL-DATA-001",
+    "val_case_002": "NOT_STARTED",
+    "experimental_commissioning": "NOT_AUTHORIZED",
+    "physical_validation": "NOT_ESTABLISHED",
+    "governing_physics_change": "NONE",
+    "next_scientific_gate": "ADDITIONAL_INDEPENDENT_DATA_REQUIRED",
+    "machine_mode_campaign_gap": "PUCKWORKS_MACHINE_MODE_CAMPAIGN_GAP"
   },
   "val_infra_002": {
     "change_declaration": "NO_GOVERNING_PHYSICS_CHANGE",

--- a/PACKAGE_QA_STATUS.json
+++ b/PACKAGE_QA_STATUS.json
@@ -30,7 +30,7 @@
     "val001_synthetic_test_count": 58,
     "static_gate_count": 38,
     "source_manifest_file_count": 226,
-    "source_manifest_aggregate_sha256": "1d7d29e811e9025a6723613606f56b80d0db7feb31944348f729493fb2a1aab6",
+    "source_manifest_aggregate_sha256": "a342fc7a23576f276bdd7b38d7f0e0c7c2fea3f458c82a74a9eaa64e06f03f54",
     "historical_baseline_integrity": "PASS",
     "active_governing_change_contract": "PASS",
     "release_integrity": "PASS",
@@ -82,7 +82,7 @@
     "future_evidence_route": "HUMAN_OWNER_PROSPECTIVE_SELECTION_REQUIRED",
     "parameter_classification_binding": "EXACT_FROZEN_VAL_CASE_001_PROTOCOL",
     "partition_rules": "ROUTE_CONDITIONAL",
-    "foreign_key_graph": "CLOSED_BY_DECLARED_PARENT_MATRIX",
+    "foreign_key_graph": "CLOSED_BY_EXACT_CANDIDATE_KEYS_AND_CROSS_TABLE_INVARIANTS",
     "measured_pressure_source_of_truth": "val_data_001_signals.csv"
   },
   "val_infra_002": {

--- a/PACKAGE_QA_STATUS.json
+++ b/PACKAGE_QA_STATUS.json
@@ -30,7 +30,7 @@
     "val001_synthetic_test_count": 58,
     "static_gate_count": 38,
     "source_manifest_file_count": 226,
-    "source_manifest_aggregate_sha256": "3c88b62caf1cb65ac9c31d8c98e43e328ae709ab8794c45e8601c1f6f5cd11b6",
+    "source_manifest_aggregate_sha256": "1cba84ad8a7d314ba5a9f2d0111c79559959214bbc75cac52f6bf131ec9a6544",
     "historical_baseline_integrity": "PASS",
     "active_governing_change_contract": "PASS",
     "release_integrity": "PASS",
@@ -113,7 +113,12 @@
     "serialization_order": "CSV_YAML_PATH_ORDER_FROZEN",
     "raw_processed_mapping": "LOCAL_TO_PUCKWORKS_FROZEN",
     "manifest_behavior": "NONRECURSIVE",
-    "compatibility_serialization_audit": "PASS"
+    "compatibility_serialization_audit": "PASS",
+    "package_operation_scope": "MODE_CONDITIONAL_AND_NONCONTRADICTORY",
+    "exported_row_state_mapping": "TOTAL_TO_PUCKWORKS_RAW_OR_PROCESSED",
+    "apparatus_calibration_scalar": "EXACT_AND_BYTE_DETERMINISTIC",
+    "source_aggregate_binding": "PACKAGE_QA_EQUALS_SOURCE_MANIFEST",
+    "state_and_serialization_audit": "PASS"
   },
   "val_infra_002": {
     "change_declaration": "NO_GOVERNING_PHYSICS_CHANGE",

--- a/PACKAGE_QA_STATUS.json
+++ b/PACKAGE_QA_STATUS.json
@@ -30,7 +30,7 @@
     "val001_synthetic_test_count": 58,
     "static_gate_count": 38,
     "source_manifest_file_count": 226,
-    "source_manifest_aggregate_sha256": "77cdb78efee5b7addd0e10f955106051e120dab95f7d37c52bde5a22994bb7dd",
+    "source_manifest_aggregate_sha256": "1d7d29e811e9025a6723613606f56b80d0db7feb31944348f729493fb2a1aab6",
     "historical_baseline_integrity": "PASS",
     "active_governing_change_contract": "PASS",
     "release_integrity": "PASS",
@@ -79,7 +79,11 @@
     "next_scientific_gate": "ADDITIONAL_INDEPENDENT_DATA_REQUIRED",
     "machine_mode_campaign_gap": "PUCKWORKS_MACHINE_MODE_CAMPAIGN_GAP",
     "review_status": "CORRECTED_PENDING_EXACT_HEAD_REVIEW",
-    "future_evidence_route": "HUMAN_OWNER_PROSPECTIVE_SELECTION_REQUIRED"
+    "future_evidence_route": "HUMAN_OWNER_PROSPECTIVE_SELECTION_REQUIRED",
+    "parameter_classification_binding": "EXACT_FROZEN_VAL_CASE_001_PROTOCOL",
+    "partition_rules": "ROUTE_CONDITIONAL",
+    "foreign_key_graph": "CLOSED_BY_DECLARED_PARENT_MATRIX",
+    "measured_pressure_source_of_truth": "val_data_001_signals.csv"
   },
   "val_infra_002": {
     "change_declaration": "NO_GOVERNING_PHYSICS_CHANGE",

--- a/PACKAGE_QA_STATUS.json
+++ b/PACKAGE_QA_STATUS.json
@@ -30,7 +30,7 @@
     "val001_synthetic_test_count": 58,
     "static_gate_count": 38,
     "source_manifest_file_count": 226,
-    "source_manifest_aggregate_sha256": "596283786d38fa725dd34441329be5d535897dfff8f2ec4aaeb2925c3a1ed12c",
+    "source_manifest_aggregate_sha256": "3af2bf2fd5fed31de21382a0104bc85b5f6c08315038594fc92e888a8008dbb8",
     "historical_baseline_integrity": "PASS",
     "active_governing_change_contract": "PASS",
     "release_integrity": "PASS",
@@ -87,7 +87,13 @@
     "source_file_nullability": "TABLE_SPECIFIC_NONCONTRADICTORY",
     "campaign_identity_mapping": "LOCAL_INSTANCE_AND_PUCKWORKS_CATALOG_SEPARATED",
     "puckworks_export_contract": "DETERMINISTIC_AUTHORITATIVE_SOURCE_BOUND",
-    "processing_lineage": "MULTI_INPUT_MULTI_OUTPUT_EDGE_GRAPH"
+    "processing_lineage": "MULTI_INPUT_MULTI_OUTPUT_EDGE_GRAPH_WITH_ROW_VALUE_AND_FILE_ASSEMBLY_SCOPES",
+    "signal_calibration_binding": "SHOT_APPARATUS_REGISTRY_AND_VALIDITY_BOUND",
+    "fraction_parent_contract": "DEFINED_WITH_NOT_APPLICABLE_STATE",
+    "compatibility_package_isolation": "ONE_EVIDENCE_PARTITION_PER_PACKAGE",
+    "resource_payload_contract": "TYPE_SPECIFIC_CANONICAL_JSON_TERMINAL_RIGHTS",
+    "synchronized_export_contract": "EXACT_GRID_SOURCE_KEYS_AND_TERMINAL_MASS_RULE",
+    "implementation_contract_audit": "PASS"
   },
   "val_infra_002": {
     "change_declaration": "NO_GOVERNING_PHYSICS_CHANGE",

--- a/PACKAGE_QA_STATUS.json
+++ b/PACKAGE_QA_STATUS.json
@@ -107,7 +107,13 @@
     "package_content_matrix": "EXACT_NULLABILITY_AND_MUTUALLY_EXCLUSIVE_FILE_SETS",
     "scalar_export_encoding": "CANONICAL_AND_BYTE_REPRODUCIBLE",
     "terminal_mass_event_binding": "REALIZED_PER_SHOT_EVENT_REQUIRED",
-    "final_export_contract_audit": "PASS"
+    "final_export_contract_audit": "PASS",
+    "typed_resource_export_members": "CLOSED_AND_RECONCILED",
+    "sealed_metadata_envelope": "SCHEMA_VALID_ONLY_NOT_PUCKWORKS_SUBMISSION",
+    "serialization_order": "CSV_YAML_PATH_ORDER_FROZEN",
+    "raw_processed_mapping": "LOCAL_TO_PUCKWORKS_FROZEN",
+    "manifest_behavior": "NONRECURSIVE",
+    "compatibility_serialization_audit": "PASS"
   },
   "val_infra_002": {
     "change_declaration": "NO_GOVERNING_PHYSICS_CHANGE",

--- a/PACKAGE_QA_STATUS.json
+++ b/PACKAGE_QA_STATUS.json
@@ -30,7 +30,7 @@
     "val001_synthetic_test_count": 58,
     "static_gate_count": 38,
     "source_manifest_file_count": 226,
-    "source_manifest_aggregate_sha256": "3af2bf2fd5fed31de21382a0104bc85b5f6c08315038594fc92e888a8008dbb8",
+    "source_manifest_aggregate_sha256": "24287ab1d23ab3b50cbe7b3a723f4cbdc1f2e71c0b26ee9347e2882897ed1032",
     "historical_baseline_integrity": "PASS",
     "active_governing_change_contract": "PASS",
     "release_integrity": "PASS",
@@ -93,7 +93,14 @@
     "compatibility_package_isolation": "ONE_EVIDENCE_PARTITION_PER_PACKAGE",
     "resource_payload_contract": "TYPE_SPECIFIC_CANONICAL_JSON_TERMINAL_RIGHTS",
     "synchronized_export_contract": "EXACT_GRID_SOURCE_KEYS_AND_TERMINAL_MASS_RULE",
-    "implementation_contract_audit": "PASS"
+    "implementation_contract_audit": "PASS",
+    "complete_key_and_resource_coverage": "PASS",
+    "package_partition_isolation": "PASS",
+    "temperature_export_contract": "REGISTERED_BASKET_TOP_SIGNAL",
+    "export_source_cardinality": "EXACT_ONE_OR_INTERPOLATED_TWO_ORDERED",
+    "fraction_chemistry_package_state": "EXPLICIT",
+    "time_series_grid_cardinality": "EXACTLY_ONE_PER_EXPORTING_PACKAGE",
+    "compatibility_export_operation_scope": "REQUIRED"
   },
   "val_infra_002": {
     "change_declaration": "NO_GOVERNING_PHYSICS_CHANGE",

--- a/PACKAGE_QA_STATUS.json
+++ b/PACKAGE_QA_STATUS.json
@@ -30,7 +30,7 @@
     "val001_synthetic_test_count": 58,
     "static_gate_count": 38,
     "source_manifest_file_count": 226,
-    "source_manifest_aggregate_sha256": "a342fc7a23576f276bdd7b38d7f0e0c7c2fea3f458c82a74a9eaa64e06f03f54",
+    "source_manifest_aggregate_sha256": "596283786d38fa725dd34441329be5d535897dfff8f2ec4aaeb2925c3a1ed12c",
     "historical_baseline_integrity": "PASS",
     "active_governing_change_contract": "PASS",
     "release_integrity": "PASS",
@@ -83,7 +83,11 @@
     "parameter_classification_binding": "EXACT_FROZEN_VAL_CASE_001_PROTOCOL",
     "partition_rules": "ROUTE_CONDITIONAL",
     "foreign_key_graph": "CLOSED_BY_EXACT_CANDIDATE_KEYS_AND_CROSS_TABLE_INVARIANTS",
-    "measured_pressure_source_of_truth": "val_data_001_signals.csv"
+    "measured_pressure_source_of_truth": "val_data_001_signals.csv",
+    "source_file_nullability": "TABLE_SPECIFIC_NONCONTRADICTORY",
+    "campaign_identity_mapping": "LOCAL_INSTANCE_AND_PUCKWORKS_CATALOG_SEPARATED",
+    "puckworks_export_contract": "DETERMINISTIC_AUTHORITATIVE_SOURCE_BOUND",
+    "processing_lineage": "MULTI_INPUT_MULTI_OUTPUT_EDGE_GRAPH"
   },
   "val_infra_002": {
     "change_declaration": "NO_GOVERNING_PHYSICS_CHANGE",

--- a/PACKAGE_QA_STATUS.json
+++ b/PACKAGE_QA_STATUS.json
@@ -30,7 +30,7 @@
     "val001_synthetic_test_count": 58,
     "static_gate_count": 38,
     "source_manifest_file_count": 226,
-    "source_manifest_aggregate_sha256": "24287ab1d23ab3b50cbe7b3a723f4cbdc1f2e71c0b26ee9347e2882897ed1032",
+    "source_manifest_aggregate_sha256": "3c88b62caf1cb65ac9c31d8c98e43e328ae709ab8794c45e8601c1f6f5cd11b6",
     "historical_baseline_integrity": "PASS",
     "active_governing_change_contract": "PASS",
     "release_integrity": "PASS",
@@ -100,7 +100,14 @@
     "export_source_cardinality": "EXACT_ONE_OR_INTERPOLATED_TWO_ORDERED",
     "fraction_chemistry_package_state": "EXPLICIT",
     "time_series_grid_cardinality": "EXACTLY_ONE_PER_EXPORTING_PACKAGE",
-    "compatibility_export_operation_scope": "REQUIRED"
+    "compatibility_export_operation_scope": "REQUIRED",
+    "conversion_domain_model": "FLOW_DENSITY_SEPARATE_FROM_FIXED_SCALE_OFFSET",
+    "processing_scope_graph": "ROW_VALUE_TO_NORMALIZED_FILE_ASSEMBLY_TO_COMPATIBILITY_EXPORT",
+    "export_provenance_classes": "NORMALIZED_RECORD_TIME_INDEXED_SAMPLES_FROZEN_LITERAL",
+    "package_content_matrix": "EXACT_NULLABILITY_AND_MUTUALLY_EXCLUSIVE_FILE_SETS",
+    "scalar_export_encoding": "CANONICAL_AND_BYTE_REPRODUCIBLE",
+    "terminal_mass_event_binding": "REALIZED_PER_SHOT_EVENT_REQUIRED",
+    "final_export_contract_audit": "PASS"
   },
   "val_infra_002": {
     "change_declaration": "NO_GOVERNING_PHYSICS_CHANGE",

--- a/SOURCE_PACKAGE_MANIFEST.json
+++ b/SOURCE_PACKAGE_MANIFEST.json
@@ -27,9 +27,9 @@
     "deterministically generated case dictionaries and case/0 fields"
   ],
   "file_count": 226,
-  "total_uncompressed_bytes_excluding_manifest": 1957470,
-  "aggregate_source_sha256": "9fb273d9187c5946352b3f7104247dc483cfa38e417c22fd262fa3fe53b8ff5a",
-  "aggregate_sha256": "9fb273d9187c5946352b3f7104247dc483cfa38e417c22fd262fa3fe53b8ff5a",
+  "total_uncompressed_bytes_excluding_manifest": 1974543,
+  "aggregate_source_sha256": "77cdb78efee5b7addd0e10f955106051e120dab95f7d37c52bde5a22994bb7dd",
+  "aggregate_sha256": "77cdb78efee5b7addd0e10f955106051e120dab95f7d37c52bde5a22994bb7dd",
   "strategy_source_path": "docs/source_strategy/espresso_puck_modeling_and_simulation_strategy_v1_4.md",
   "strategy_source_sha256": "3e3b96b39f81c5e2df5c2dbe42103a4a5a58f928b9e5409bbcaeb861761377b9",
   "files": {
@@ -444,8 +444,8 @@
       "git_mode": "100644"
     },
     "docs/QA_STATUS.md": {
-      "sha256": "d729311d3ecaa12a7c54734eaa4acf6f6c2fa76b95f742d7ee3f03259565805d",
-      "bytes": 8402,
+      "sha256": "2202f692453e9fbb9e92546584004cbd5363d481707d77e4cd6dea39a1e213f2",
+      "bytes": 8810,
       "git_mode": "100644"
     },
     "docs/RUNBOOK_AND_TROUBLESHOOTING.md": {
@@ -549,8 +549,8 @@
       "git_mode": "100644"
     },
     "docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md": {
-      "sha256": "33cd97c6ea672102c4a2808de243c4ffb9a714f3f1c776d6fc86ba0746bfe143",
-      "bytes": 12209,
+      "sha256": "411a37324a602447fed08a4cfa35597ca6349c3c1cbf03f586f124e2d89884d4",
+      "bytes": 28874,
       "git_mode": "100644"
     },
     "docs/validation/VAL_INFRA_002_STAGE0_VERIFIER_SCOPE_REPAIR.md": {

--- a/SOURCE_PACKAGE_MANIFEST.json
+++ b/SOURCE_PACKAGE_MANIFEST.json
@@ -27,9 +27,9 @@
     "deterministically generated case dictionaries and case/0 fields"
   ],
   "file_count": 226,
-  "total_uncompressed_bytes_excluding_manifest": 2048897,
-  "aggregate_source_sha256": "94971ef9a5141a012f03f88d360f85cd05357c7344f515cb57f21793cb1773d3",
-  "aggregate_sha256": "94971ef9a5141a012f03f88d360f85cd05357c7344f515cb57f21793cb1773d3",
+  "total_uncompressed_bytes_excluding_manifest": 2051430,
+  "aggregate_source_sha256": "1cba84ad8a7d314ba5a9f2d0111c79559959214bbc75cac52f6bf131ec9a6544",
+  "aggregate_sha256": "1cba84ad8a7d314ba5a9f2d0111c79559959214bbc75cac52f6bf131ec9a6544",
   "strategy_source_path": "docs/source_strategy/espresso_puck_modeling_and_simulation_strategy_v1_4.md",
   "strategy_source_sha256": "3e3b96b39f81c5e2df5c2dbe42103a4a5a58f928b9e5409bbcaeb861761377b9",
   "files": {
@@ -444,8 +444,8 @@
       "git_mode": "100644"
     },
     "docs/QA_STATUS.md": {
-      "sha256": "73eb066ce092b5860acc198b8afaf391815091c1ebfa91007315c1469cc1b363",
-      "bytes": 10999,
+      "sha256": "1290fd4b5ecc3bbb340e730c4e8ef44a8ca786fb49361098676aa23b2968b428",
+      "bytes": 11287,
       "git_mode": "100644"
     },
     "docs/RUNBOOK_AND_TROUBLESHOOTING.md": {
@@ -549,8 +549,8 @@
       "git_mode": "100644"
     },
     "docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md": {
-      "sha256": "7dc95b3197891de1e458586ac239267daaeab7b57858ed8dc4611792b6429faf",
-      "bytes": 101039,
+      "sha256": "978d0711787a6604f088720327d4689102729646d4df57f96a6e121e119c5fc5",
+      "bytes": 103284,
       "git_mode": "100644"
     },
     "docs/validation/VAL_INFRA_002_STAGE0_VERIFIER_SCOPE_REPAIR.md": {

--- a/SOURCE_PACKAGE_MANIFEST.json
+++ b/SOURCE_PACKAGE_MANIFEST.json
@@ -26,10 +26,10 @@
     "Make/linux*/ build products",
     "deterministically generated case dictionaries and case/0 fields"
   ],
-  "file_count": 225,
-  "total_uncompressed_bytes_excluding_manifest": 1943810,
-  "aggregate_source_sha256": "38012831244266d74cf7374d07737c5c159354f5382763b16255deb4c18866cf",
-  "aggregate_sha256": "38012831244266d74cf7374d07737c5c159354f5382763b16255deb4c18866cf",
+  "file_count": 226,
+  "total_uncompressed_bytes_excluding_manifest": 1957470,
+  "aggregate_source_sha256": "9fb273d9187c5946352b3f7104247dc483cfa38e417c22fd262fa3fe53b8ff5a",
+  "aggregate_sha256": "9fb273d9187c5946352b3f7104247dc483cfa38e417c22fd262fa3fe53b8ff5a",
   "strategy_source_path": "docs/source_strategy/espresso_puck_modeling_and_simulation_strategy_v1_4.md",
   "strategy_source_sha256": "3e3b96b39f81c5e2df5c2dbe42103a4a5a58f928b9e5409bbcaeb861761377b9",
   "files": {
@@ -444,8 +444,8 @@
       "git_mode": "100644"
     },
     "docs/QA_STATUS.md": {
-      "sha256": "5bfb6c856795016e575fb45c7cbd23a383358c8f8a3af821800cc1db7848ccb2",
-      "bytes": 8083,
+      "sha256": "d729311d3ecaa12a7c54734eaa4acf6f6c2fa76b95f742d7ee3f03259565805d",
+      "bytes": 8402,
       "git_mode": "100644"
     },
     "docs/RUNBOOK_AND_TROUBLESHOOTING.md": {
@@ -548,6 +548,11 @@
       "bytes": 6546,
       "git_mode": "100644"
     },
+    "docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md": {
+      "sha256": "33cd97c6ea672102c4a2808de243c4ffb9a714f3f1c776d6fc86ba0746bfe143",
+      "bytes": 12209,
+      "git_mode": "100644"
+    },
     "docs/validation/VAL_INFRA_002_STAGE0_VERIFIER_SCOPE_REPAIR.md": {
       "sha256": "ca9c24beeacadd8188024e1eec632338b16b05d141aaafd5fc166e81fdd59c60",
       "bytes": 2707,
@@ -559,8 +564,8 @@
       "git_mode": "100644"
     },
     "docs/validation/cases/VAL_CASE_001_HYDRAULIC_COMPACTION_IDENTIFIABILITY_RESULTS.md": {
-      "sha256": "dcb7a6615da740681b7268256f137fe87276bc694d43c012b0878023eeb2ff26",
-      "bytes": 12474,
+      "sha256": "b06a2049270ed62a8ae447b6ab6ea82237d47454267849a8615241102d6078ce",
+      "bytes": 13606,
       "git_mode": "100644"
     },
     "docs/validation/cases/VAL_CASE_001_PROTOCOL.md": {

--- a/SOURCE_PACKAGE_MANIFEST.json
+++ b/SOURCE_PACKAGE_MANIFEST.json
@@ -27,9 +27,9 @@
     "deterministically generated case dictionaries and case/0 fields"
   ],
   "file_count": 226,
-  "total_uncompressed_bytes_excluding_manifest": 1983649,
-  "aggregate_source_sha256": "1d7d29e811e9025a6723613606f56b80d0db7feb31944348f729493fb2a1aab6",
-  "aggregate_sha256": "1d7d29e811e9025a6723613606f56b80d0db7feb31944348f729493fb2a1aab6",
+  "total_uncompressed_bytes_excluding_manifest": 1992212,
+  "aggregate_source_sha256": "a342fc7a23576f276bdd7b38d7f0e0c7c2fea3f458c82a74a9eaa64e06f03f54",
+  "aggregate_sha256": "a342fc7a23576f276bdd7b38d7f0e0c7c2fea3f458c82a74a9eaa64e06f03f54",
   "strategy_source_path": "docs/source_strategy/espresso_puck_modeling_and_simulation_strategy_v1_4.md",
   "strategy_source_sha256": "3e3b96b39f81c5e2df5c2dbe42103a4a5a58f928b9e5409bbcaeb861761377b9",
   "files": {
@@ -444,8 +444,8 @@
       "git_mode": "100644"
     },
     "docs/QA_STATUS.md": {
-      "sha256": "44134f60d41e623a8ee24594eaa1e80b2d427833fa062f462c8103f97592fcb2",
-      "bytes": 9075,
+      "sha256": "5f88552fdd9ca62e708b0fc8f3ca67fe00a9c4ba942771a6687ae07fc64eb2c7",
+      "bytes": 9305,
       "git_mode": "100644"
     },
     "docs/RUNBOOK_AND_TROUBLESHOOTING.md": {
@@ -549,8 +549,8 @@
       "git_mode": "100644"
     },
     "docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md": {
-      "sha256": "51b5d35f0d82e1987438b9db2fa69bf83df34cbb15704bee5d846bf68d5913b5",
-      "bytes": 37715,
+      "sha256": "5b742595b37ca639823eeaa3457641cdf59fd5e48bf5b56f5eb8ec7528fb5549",
+      "bytes": 46048,
       "git_mode": "100644"
     },
     "docs/validation/VAL_INFRA_002_STAGE0_VERIFIER_SCOPE_REPAIR.md": {

--- a/SOURCE_PACKAGE_MANIFEST.json
+++ b/SOURCE_PACKAGE_MANIFEST.json
@@ -27,9 +27,9 @@
     "deterministically generated case dictionaries and case/0 fields"
   ],
   "file_count": 226,
-  "total_uncompressed_bytes_excluding_manifest": 2042226,
-  "aggregate_source_sha256": "3c88b62caf1cb65ac9c31d8c98e43e328ae709ab8794c45e8601c1f6f5cd11b6",
-  "aggregate_sha256": "3c88b62caf1cb65ac9c31d8c98e43e328ae709ab8794c45e8601c1f6f5cd11b6",
+  "total_uncompressed_bytes_excluding_manifest": 2048897,
+  "aggregate_source_sha256": "94971ef9a5141a012f03f88d360f85cd05357c7344f515cb57f21793cb1773d3",
+  "aggregate_sha256": "94971ef9a5141a012f03f88d360f85cd05357c7344f515cb57f21793cb1773d3",
   "strategy_source_path": "docs/source_strategy/espresso_puck_modeling_and_simulation_strategy_v1_4.md",
   "strategy_source_sha256": "3e3b96b39f81c5e2df5c2dbe42103a4a5a58f928b9e5409bbcaeb861761377b9",
   "files": {
@@ -444,8 +444,8 @@
       "git_mode": "100644"
     },
     "docs/QA_STATUS.md": {
-      "sha256": "0329c43b2dd865a16130107779c162c3faadcfb70e7dbb79fc30f19a4ad7e9bc",
-      "bytes": 10693,
+      "sha256": "73eb066ce092b5860acc198b8afaf391815091c1ebfa91007315c1469cc1b363",
+      "bytes": 10999,
       "git_mode": "100644"
     },
     "docs/RUNBOOK_AND_TROUBLESHOOTING.md": {
@@ -549,8 +549,8 @@
       "git_mode": "100644"
     },
     "docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md": {
-      "sha256": "a8207f4fcd574a35bbdc45601fa686ae8a041ed3a33ee224d2b472431e4bbeb8",
-      "bytes": 94674,
+      "sha256": "7dc95b3197891de1e458586ac239267daaeab7b57858ed8dc4611792b6429faf",
+      "bytes": 101039,
       "git_mode": "100644"
     },
     "docs/validation/VAL_INFRA_002_STAGE0_VERIFIER_SCOPE_REPAIR.md": {

--- a/SOURCE_PACKAGE_MANIFEST.json
+++ b/SOURCE_PACKAGE_MANIFEST.json
@@ -27,9 +27,9 @@
     "deterministically generated case dictionaries and case/0 fields"
   ],
   "file_count": 226,
-  "total_uncompressed_bytes_excluding_manifest": 1992212,
-  "aggregate_source_sha256": "a342fc7a23576f276bdd7b38d7f0e0c7c2fea3f458c82a74a9eaa64e06f03f54",
-  "aggregate_sha256": "a342fc7a23576f276bdd7b38d7f0e0c7c2fea3f458c82a74a9eaa64e06f03f54",
+  "total_uncompressed_bytes_excluding_manifest": 2005752,
+  "aggregate_source_sha256": "596283786d38fa725dd34441329be5d535897dfff8f2ec4aaeb2925c3a1ed12c",
+  "aggregate_sha256": "596283786d38fa725dd34441329be5d535897dfff8f2ec4aaeb2925c3a1ed12c",
   "strategy_source_path": "docs/source_strategy/espresso_puck_modeling_and_simulation_strategy_v1_4.md",
   "strategy_source_sha256": "3e3b96b39f81c5e2df5c2dbe42103a4a5a58f928b9e5409bbcaeb861761377b9",
   "files": {
@@ -444,8 +444,8 @@
       "git_mode": "100644"
     },
     "docs/QA_STATUS.md": {
-      "sha256": "5f88552fdd9ca62e708b0fc8f3ca67fe00a9c4ba942771a6687ae07fc64eb2c7",
-      "bytes": 9305,
+      "sha256": "024b83a2019da6ee40b6c47acc7ba58d4337dbf36ffc92c37aa3b8471729c0bb",
+      "bytes": 9502,
       "git_mode": "100644"
     },
     "docs/RUNBOOK_AND_TROUBLESHOOTING.md": {
@@ -549,8 +549,8 @@
       "git_mode": "100644"
     },
     "docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md": {
-      "sha256": "5b742595b37ca639823eeaa3457641cdf59fd5e48bf5b56f5eb8ec7528fb5549",
-      "bytes": 46048,
+      "sha256": "221da1f436c86f8864427c21544ae3d0c11c7ce36c0d29fca775bcd61654cf0e",
+      "bytes": 59391,
       "git_mode": "100644"
     },
     "docs/validation/VAL_INFRA_002_STAGE0_VERIFIER_SCOPE_REPAIR.md": {

--- a/SOURCE_PACKAGE_MANIFEST.json
+++ b/SOURCE_PACKAGE_MANIFEST.json
@@ -27,9 +27,9 @@
     "deterministically generated case dictionaries and case/0 fields"
   ],
   "file_count": 226,
-  "total_uncompressed_bytes_excluding_manifest": 2029120,
-  "aggregate_source_sha256": "24287ab1d23ab3b50cbe7b3a723f4cbdc1f2e71c0b26ee9347e2882897ed1032",
-  "aggregate_sha256": "24287ab1d23ab3b50cbe7b3a723f4cbdc1f2e71c0b26ee9347e2882897ed1032",
+  "total_uncompressed_bytes_excluding_manifest": 2042226,
+  "aggregate_source_sha256": "3c88b62caf1cb65ac9c31d8c98e43e328ae709ab8794c45e8601c1f6f5cd11b6",
+  "aggregate_sha256": "3c88b62caf1cb65ac9c31d8c98e43e328ae709ab8794c45e8601c1f6f5cd11b6",
   "strategy_source_path": "docs/source_strategy/espresso_puck_modeling_and_simulation_strategy_v1_4.md",
   "strategy_source_sha256": "3e3b96b39f81c5e2df5c2dbe42103a4a5a58f928b9e5409bbcaeb861761377b9",
   "files": {
@@ -444,8 +444,8 @@
       "git_mode": "100644"
     },
     "docs/QA_STATUS.md": {
-      "sha256": "541f38f37676ff134902c752726e012d82890da08898a84184b8d35b21b38014",
-      "bytes": 10342,
+      "sha256": "0329c43b2dd865a16130107779c162c3faadcfb70e7dbb79fc30f19a4ad7e9bc",
+      "bytes": 10693,
       "git_mode": "100644"
     },
     "docs/RUNBOOK_AND_TROUBLESHOOTING.md": {
@@ -549,8 +549,8 @@
       "git_mode": "100644"
     },
     "docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md": {
-      "sha256": "c561091103d79e35d30fe6687145c66fafd67918400de7f04723edb9deae7df5",
-      "bytes": 81919,
+      "sha256": "a8207f4fcd574a35bbdc45601fa686ae8a041ed3a33ee224d2b472431e4bbeb8",
+      "bytes": 94674,
       "git_mode": "100644"
     },
     "docs/validation/VAL_INFRA_002_STAGE0_VERIFIER_SCOPE_REPAIR.md": {

--- a/SOURCE_PACKAGE_MANIFEST.json
+++ b/SOURCE_PACKAGE_MANIFEST.json
@@ -27,9 +27,9 @@
     "deterministically generated case dictionaries and case/0 fields"
   ],
   "file_count": 226,
-  "total_uncompressed_bytes_excluding_manifest": 1974543,
-  "aggregate_source_sha256": "77cdb78efee5b7addd0e10f955106051e120dab95f7d37c52bde5a22994bb7dd",
-  "aggregate_sha256": "77cdb78efee5b7addd0e10f955106051e120dab95f7d37c52bde5a22994bb7dd",
+  "total_uncompressed_bytes_excluding_manifest": 1983649,
+  "aggregate_source_sha256": "1d7d29e811e9025a6723613606f56b80d0db7feb31944348f729493fb2a1aab6",
+  "aggregate_sha256": "1d7d29e811e9025a6723613606f56b80d0db7feb31944348f729493fb2a1aab6",
   "strategy_source_path": "docs/source_strategy/espresso_puck_modeling_and_simulation_strategy_v1_4.md",
   "strategy_source_sha256": "3e3b96b39f81c5e2df5c2dbe42103a4a5a58f928b9e5409bbcaeb861761377b9",
   "files": {
@@ -444,8 +444,8 @@
       "git_mode": "100644"
     },
     "docs/QA_STATUS.md": {
-      "sha256": "2202f692453e9fbb9e92546584004cbd5363d481707d77e4cd6dea39a1e213f2",
-      "bytes": 8810,
+      "sha256": "44134f60d41e623a8ee24594eaa1e80b2d427833fa062f462c8103f97592fcb2",
+      "bytes": 9075,
       "git_mode": "100644"
     },
     "docs/RUNBOOK_AND_TROUBLESHOOTING.md": {
@@ -549,8 +549,8 @@
       "git_mode": "100644"
     },
     "docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md": {
-      "sha256": "411a37324a602447fed08a4cfa35597ca6349c3c1cbf03f586f124e2d89884d4",
-      "bytes": 28874,
+      "sha256": "51b5d35f0d82e1987438b9db2fa69bf83df34cbb15704bee5d846bf68d5913b5",
+      "bytes": 37715,
       "git_mode": "100644"
     },
     "docs/validation/VAL_INFRA_002_STAGE0_VERIFIER_SCOPE_REPAIR.md": {

--- a/SOURCE_PACKAGE_MANIFEST.json
+++ b/SOURCE_PACKAGE_MANIFEST.json
@@ -27,9 +27,9 @@
     "deterministically generated case dictionaries and case/0 fields"
   ],
   "file_count": 226,
-  "total_uncompressed_bytes_excluding_manifest": 2005752,
-  "aggregate_source_sha256": "596283786d38fa725dd34441329be5d535897dfff8f2ec4aaeb2925c3a1ed12c",
-  "aggregate_sha256": "596283786d38fa725dd34441329be5d535897dfff8f2ec4aaeb2925c3a1ed12c",
+  "total_uncompressed_bytes_excluding_manifest": 2018616,
+  "aggregate_source_sha256": "3af2bf2fd5fed31de21382a0104bc85b5f6c08315038594fc92e888a8008dbb8",
+  "aggregate_sha256": "3af2bf2fd5fed31de21382a0104bc85b5f6c08315038594fc92e888a8008dbb8",
   "strategy_source_path": "docs/source_strategy/espresso_puck_modeling_and_simulation_strategy_v1_4.md",
   "strategy_source_sha256": "3e3b96b39f81c5e2df5c2dbe42103a4a5a58f928b9e5409bbcaeb861761377b9",
   "files": {
@@ -444,8 +444,8 @@
       "git_mode": "100644"
     },
     "docs/QA_STATUS.md": {
-      "sha256": "024b83a2019da6ee40b6c47acc7ba58d4337dbf36ffc92c37aa3b8471729c0bb",
-      "bytes": 9502,
+      "sha256": "03bc1a73e41e5d307d4279c2df5af5bb1a3093de933896a97dfe08dccffbb647",
+      "bytes": 9978,
       "git_mode": "100644"
     },
     "docs/RUNBOOK_AND_TROUBLESHOOTING.md": {
@@ -549,8 +549,8 @@
       "git_mode": "100644"
     },
     "docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md": {
-      "sha256": "221da1f436c86f8864427c21544ae3d0c11c7ce36c0d29fca775bcd61654cf0e",
-      "bytes": 59391,
+      "sha256": "7069cc583af30ea51545ee874fdc8b4f71e33c8ff7838c06df59f13693980c58",
+      "bytes": 71779,
       "git_mode": "100644"
     },
     "docs/validation/VAL_INFRA_002_STAGE0_VERIFIER_SCOPE_REPAIR.md": {

--- a/SOURCE_PACKAGE_MANIFEST.json
+++ b/SOURCE_PACKAGE_MANIFEST.json
@@ -27,9 +27,9 @@
     "deterministically generated case dictionaries and case/0 fields"
   ],
   "file_count": 226,
-  "total_uncompressed_bytes_excluding_manifest": 2018616,
-  "aggregate_source_sha256": "3af2bf2fd5fed31de21382a0104bc85b5f6c08315038594fc92e888a8008dbb8",
-  "aggregate_sha256": "3af2bf2fd5fed31de21382a0104bc85b5f6c08315038594fc92e888a8008dbb8",
+  "total_uncompressed_bytes_excluding_manifest": 2029120,
+  "aggregate_source_sha256": "24287ab1d23ab3b50cbe7b3a723f4cbdc1f2e71c0b26ee9347e2882897ed1032",
+  "aggregate_sha256": "24287ab1d23ab3b50cbe7b3a723f4cbdc1f2e71c0b26ee9347e2882897ed1032",
   "strategy_source_path": "docs/source_strategy/espresso_puck_modeling_and_simulation_strategy_v1_4.md",
   "strategy_source_sha256": "3e3b96b39f81c5e2df5c2dbe42103a4a5a58f928b9e5409bbcaeb861761377b9",
   "files": {
@@ -444,8 +444,8 @@
       "git_mode": "100644"
     },
     "docs/QA_STATUS.md": {
-      "sha256": "03bc1a73e41e5d307d4279c2df5af5bb1a3093de933896a97dfe08dccffbb647",
-      "bytes": 9978,
+      "sha256": "541f38f37676ff134902c752726e012d82890da08898a84184b8d35b21b38014",
+      "bytes": 10342,
       "git_mode": "100644"
     },
     "docs/RUNBOOK_AND_TROUBLESHOOTING.md": {
@@ -549,8 +549,8 @@
       "git_mode": "100644"
     },
     "docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md": {
-      "sha256": "7069cc583af30ea51545ee874fdc8b4f71e33c8ff7838c06df59f13693980c58",
-      "bytes": 71779,
+      "sha256": "c561091103d79e35d30fe6687145c66fafd67918400de7f04723edb9deae7df5",
+      "bytes": 81919,
       "git_mode": "100644"
     },
     "docs/validation/VAL_INFRA_002_STAGE0_VERIFIER_SCOPE_REPAIR.md": {

--- a/docs/DEVELOPMENT_HISTORY.md
+++ b/docs/DEVELOPMENT_HISTORY.md
@@ -207,3 +207,12 @@ The final template-interoperability correction separated local campaign
 instances from Puckworks catalog IDs, defined deterministic field-level export
 bindings, removed generic source-file nullability, and replaced one-to-one
 lineage with an acyclic multi-input/multi-output edge graph.
+
+The implementation-contract closure then bound samples and deformation to the
+shot apparatus and registered channel, replaced missingness-driven calibration
+rules with registry applicability and validity rules, added fraction parents,
+partition-isolated compatibility packages, typed canonical resource payloads
+and terminal rights, separated row-value operations from file assembly, and
+froze reproducible synchronized-time-series and terminal delivered-mass export
+rules. This was documentation and schema-contract work only; no acquisition,
+scientific execution, scoring, or governing-physics change occurred.

--- a/docs/DEVELOPMENT_HISTORY.md
+++ b/docs/DEVELOPMENT_HISTORY.md
@@ -216,3 +216,11 @@ and terminal rights, separated row-value operations from file assembly, and
 froze reproducible synchronized-time-series and terminal delivered-mass export
 rules. This was documentation and schema-contract work only; no acquisition,
 scientific execution, scoring, or governing-physics change occurred.
+
+The final machine-contract closure completed omitted foreign-key and resource
+bindings, scoped every compatibility identity and summary to one evidence
+partition, added registered basket-top temperature and reproducible exact or
+two-sample interpolation sources, introduced package-level fraction/chemistry
+status, and required exactly one grid and one compatibility-export operation
+for each time-series package. It changed no accepted science, evidence route,
+measurement target, result, dependency, or commissioning boundary.

--- a/docs/DEVELOPMENT_HISTORY.md
+++ b/docs/DEVELOPMENT_HISTORY.md
@@ -231,3 +231,10 @@ compatibility-export layering, divided time-indexed and record/literal source
 provenance, froze package content modes and scalar encodings, and introduced
 the realized per-shot termination event used for terminal delivered mass. No
 scientific result, evidence route, experiment, dependency, or physics changed.
+
+The compatibility-serialization closure then reconciled exported typed
+resource members with their closed schemas, defined the metadata-only sealed
+envelope as distinct from a Puckworks submission, froze deterministic YAML and
+CSV serialization, mapped local provenance to Puckworks `raw`/`processed`, and
+made manifests explicitly nonrecursive. No evidence or scientific execution
+occurred.

--- a/docs/DEVELOPMENT_HISTORY.md
+++ b/docs/DEVELOPMENT_HISTORY.md
@@ -183,3 +183,11 @@ rights, and deposit package. The plan records a separate upstream
 machine-pressure campaign gap and leaves sensors, pilot, feasibility,
 replication, and commissioning unresolved. No result, experiment, data,
 OpenFOAM, fit, Puckworks state, solver, framework, or physics changed.
+
+Independent exact-head review required a bounded documentation correction.
+The corrected plan replaces the unconditional evidence-class statement with a
+prospective human-owner route decision, binds prescribed targets to measured
+basket-top pressure, and adds parameter/evidence-role, normalized submission
+schema, timing, and deformation-compliance contracts. Status is
+`CORRECTED_PENDING_EXACT_HEAD_REVIEW`; the accepted erratum and all scientific
+artifacts remain unchanged.

--- a/docs/DEVELOPMENT_HISTORY.md
+++ b/docs/DEVELOPMENT_HISTORY.md
@@ -238,3 +238,10 @@ envelope as distinct from a Puckworks submission, froze deterministic YAML and
 CSV serialization, mapped local provenance to Puckworks `raw`/`processed`, and
 made manifests explicitly nonrecursive. No evidence or scientific execution
 occurred.
+
+The state-and-serialization consistency correction then made export-operation
+foreign keys conditional on package mode, added the disjoint sealed-envelope
+graph branch, removed unreachable stored status, completed time-series
+row-state mapping, froze the apparatus calibration scalar and YAML emitter,
+and synchronized package QA with the current source manifest. It changed no
+accepted scientific or experimental-design content.

--- a/docs/DEVELOPMENT_HISTORY.md
+++ b/docs/DEVELOPMENT_HISTORY.md
@@ -191,3 +191,9 @@ basket-top pressure, and adds parameter/evidence-role, normalized submission
 schema, timing, and deformation-compliance contracts. Status is
 `CORRECTED_PENDING_EXACT_HEAD_REVIEW`; the accepted erratum and all scientific
 artifacts remain unchanged.
+
+A final bounded evidence/schema correction then restored the frozen
+VAL-CASE-001 parameter classifications exactly, made replication and access
+rules conditional on the selected route, closed the normalized foreign-key
+graph, and designated the signal table as the sole measured-pressure source.
+No scientific artifact, code, dependency, experiment, or claim changed.

--- a/docs/DEVELOPMENT_HISTORY.md
+++ b/docs/DEVELOPMENT_HISTORY.md
@@ -173,3 +173,13 @@ the v2 result SHA-256 remains
 `bb7bba7481a56ac8729758a6d5cd36e7d046b889256a7c1d1c8ed7cff998375a`.
 The next scientific gate is `ADDITIONAL_INDEPENDENT_DATA_REQUIRED`; VAL-CASE-002
 remains not started and no new physics or experimental work is authorized.
+
+## 2026-08-01 — VAL-DATA-001 synchronized measurement planning
+
+A documentation-only task corrected the campaign cross-reference by
+append-only erratum and specified a future synchronized pressure, flow/mass,
+deformation, timing, metadata, calibration, uncertainty, replication, holdout,
+rights, and deposit package. The plan records a separate upstream
+machine-pressure campaign gap and leaves sensors, pilot, feasibility,
+replication, and commissioning unresolved. No result, experiment, data,
+OpenFOAM, fit, Puckworks state, solver, framework, or physics changed.

--- a/docs/DEVELOPMENT_HISTORY.md
+++ b/docs/DEVELOPMENT_HISTORY.md
@@ -202,3 +202,8 @@ A subsequent referential-integrity correction replaced incomplete signal and
 resource references with exact candidate keys, distinguished locked templates
 from future instances, and added deterministic cross-table invariants. The
 accepted plan content and all scientific boundaries remain unchanged.
+
+The final template-interoperability correction separated local campaign
+instances from Puckworks catalog IDs, defined deterministic field-level export
+bindings, removed generic source-file nullability, and replaced one-to-one
+lineage with an acyclic multi-input/multi-output edge graph.

--- a/docs/DEVELOPMENT_HISTORY.md
+++ b/docs/DEVELOPMENT_HISTORY.md
@@ -224,3 +224,10 @@ two-sample interpolation sources, introduced package-level fraction/chemistry
 status, and required exactly one grid and one compatibility-export operation
 for each time-series package. It changed no accepted science, evidence route,
 measurement target, result, dependency, or commissioning boundary.
+
+The final export-contract reconciliation separated flow/density conversion
+from fixed unit scaling, enforced row-value to normalized-assembly to
+compatibility-export layering, divided time-indexed and record/literal source
+provenance, froze package content modes and scalar encodings, and introduced
+the realized per-shot termination event used for terminal delivered mass. No
+scientific result, evidence route, experiment, dependency, or physics changed.

--- a/docs/DEVELOPMENT_HISTORY.md
+++ b/docs/DEVELOPMENT_HISTORY.md
@@ -197,3 +197,8 @@ VAL-CASE-001 parameter classifications exactly, made replication and access
 rules conditional on the selected route, closed the normalized foreign-key
 graph, and designated the signal table as the sole measured-pressure source.
 No scientific artifact, code, dependency, experiment, or claim changed.
+
+A subsequent referential-integrity correction replaced incomplete signal and
+resource references with exact candidate keys, distinguished locked templates
+from future instances, and added deterministic cross-table invariants. The
+accepted plan content and all scientific boundaries remain unchanged.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -7,8 +7,9 @@
 - Archival baseline: WP-0.1H v0.1.4, `FROZEN / QUALIFIED`
 - OpenFOAM target: Foundation 12
 - Puckworks integration: locked external checkout, no submodule
-- Public source verification: 225/225 PASS
+- Public source verification: 226/226 PASS
 - Active validation case: `NONE`
+- Active data-planning task: `VAL-DATA-001`
 - Physical validation: `NOT_ESTABLISHED`
 - Experimental commissioning: `NOT_AUTHORIZED`
 - Protected or holdout scoring: `NOT_AUTHORIZED`
@@ -26,6 +27,10 @@ admissible independent dataset or the synchronized pressure, flow/mass,
 deformation, machine-side pressure, timing, and preparation measurement
 package identified by VAL-CASE-001. No acquisition, commissioning, or new
 governing physics is authorized by the administrative closure.
+
+VAL-DATA-001 is an active non-commissioning planning task for the synchronized
+measurement package. `EXPERIMENTAL_COMMISSIONING: NOT_AUTHORIZED`,
+`GOVERNING_PHYSICS_CHANGE: NONE`, and VAL-CASE-002 remains `NOT_STARTED`.
 
 VAL-INFRA-002 is a merged reusable-infrastructure repair that scopes the
 legacy WP-0.3C Stage-0 verifier scope. It changes no scientific result,

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -34,6 +34,9 @@ measurement package. `EXPERIMENTAL_COMMISSIONING: NOT_AUTHORIZED`,
 Its exact-head review correction status is
 `VAL_DATA_001_REVIEW_STATUS: CORRECTED_PENDING_EXACT_HEAD_REVIEW`; the future
 evidence route still requires prospective human-owner selection.
+The final schema correction restores exact frozen VAL-CASE-001 parameter
+classifications, makes partition rules route-conditional, closes all declared
+foreign keys, and assigns measured pressure to one authoritative signal table.
 
 VAL-INFRA-002 is a merged reusable-infrastructure repair that scopes the
 legacy WP-0.3C Stage-0 verifier scope. It changes no scientific result,

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -31,6 +31,9 @@ governing physics is authorized by the administrative closure.
 VAL-DATA-001 is an active non-commissioning planning task for the synchronized
 measurement package. `EXPERIMENTAL_COMMISSIONING: NOT_AUTHORIZED`,
 `GOVERNING_PHYSICS_CHANGE: NONE`, and VAL-CASE-002 remains `NOT_STARTED`.
+Its exact-head review correction status is
+`VAL_DATA_001_REVIEW_STATUS: CORRECTED_PENDING_EXACT_HEAD_REVIEW`; the future
+evidence route still requires prospective human-owner selection.
 
 VAL-INFRA-002 is a merged reusable-infrastructure repair that scopes the
 legacy WP-0.3C Stage-0 verifier scope. It changes no scientific result,

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -65,6 +65,11 @@ defines a sealed metadata envelope distinct from a Puckworks submission,
 freezes row and nested-field ordering, maps local provenance to Puckworks
 `raw`/`processed`, and removes recursive manifest dependencies. Review remains
 pending and commissioning remains unauthorized.
+The state-and-serialization consistency correction makes package-operation
+references mode-conditional, gives full and sealed exports disjoint graph
+branches, removes unreachable status values, makes row provenance mapping
+total, and freezes the apparatus calibration scalar and YAML emitter. Package
+QA now binds the current source-manifest identity exactly.
 
 VAL-INFRA-002 is a merged reusable-infrastructure repair that scopes the
 legacy WP-0.3C Stage-0 verifier scope. It changes no scientific result,

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -49,6 +49,12 @@ registry-controlled, adds fraction parents and partition-isolated
 compatibility packages, types resource payloads with terminal rights, and
 separates row-value processing from file assembly and exact synchronized
 exports. Commissioning remains unauthorized.
+The final machine-contract closure completes all field/reference bindings,
+makes package identities and summaries partition-specific, adds registered
+basket-top temperature, records exact or two-source interpolated export
+provenance, adds package-level fraction/chemistry disposition, and enforces
+one export grid and one `COMPATIBILITY_EXPORT` operation per time-series
+package.
 
 VAL-INFRA-002 is a merged reusable-infrastructure repair that scopes the
 legacy WP-0.3C Stage-0 verifier scope. It changes no scientific result,

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -55,6 +55,11 @@ basket-top temperature, records exact or two-source interpolated export
 provenance, adds package-level fraction/chemistry disposition, and enforces
 one export grid and one `COMPATIBILITY_EXPORT` operation per time-series
 package.
+The final export-contract reconciliation separates fixed unit conversion from
+flow/density conversion, enforces the three-layer processing graph, separates
+time-indexed samples from record/literal provenance, freezes package-mode
+nullability and scalar encodings, and binds terminal mass to a realized shot
+event. The task remains non-commissioning.
 
 VAL-INFRA-002 is a merged reusable-infrastructure repair that scopes the
 legacy WP-0.3C Stage-0 verifier scope. It changes no scientific result,

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -37,6 +37,9 @@ evidence route still requires prospective human-owner selection.
 The final schema correction restores exact frozen VAL-CASE-001 parameter
 classifications, makes partition rules route-conditional, closes all declared
 foreign keys, and assigns measured pressure to one authoritative signal table.
+The referential-integrity correction binds complete pressure-sample keys,
+global resource keys, table-specific null rules, and cross-table campaign and
+route invariants; status remains `CORRECTED_PENDING_EXACT_HEAD_REVIEW`.
 
 VAL-INFRA-002 is a merged reusable-infrastructure repair that scopes the
 legacy WP-0.3C Stage-0 verifier scope. It changes no scientific result,

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -43,6 +43,12 @@ route invariants; status remains `CORRECTED_PENDING_EXACT_HEAD_REVIEW`.
 The template-interoperability correction separates local campaign instances
 from catalog IDs, adds deterministic Puckworks exports, and represents
 processing lineage as an acyclic multi-input/multi-output edge graph.
+The implementation-contract closure binds samples and deformation to the
+shot apparatus and signal registry, makes calibration applicability
+registry-controlled, adds fraction parents and partition-isolated
+compatibility packages, types resource payloads with terminal rights, and
+separates row-value processing from file assembly and exact synchronized
+exports. Commissioning remains unauthorized.
 
 VAL-INFRA-002 is a merged reusable-infrastructure repair that scopes the
 legacy WP-0.3C Stage-0 verifier scope. It changes no scientific result,

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -40,6 +40,9 @@ foreign keys, and assigns measured pressure to one authoritative signal table.
 The referential-integrity correction binds complete pressure-sample keys,
 global resource keys, table-specific null rules, and cross-table campaign and
 route invariants; status remains `CORRECTED_PENDING_EXACT_HEAD_REVIEW`.
+The template-interoperability correction separates local campaign instances
+from catalog IDs, adds deterministic Puckworks exports, and represents
+processing lineage as an acyclic multi-input/multi-output edge graph.
 
 VAL-INFRA-002 is a merged reusable-infrastructure repair that scopes the
 legacy WP-0.3C Stage-0 verifier scope. It changes no scientific result,

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -60,6 +60,11 @@ flow/density conversion, enforces the three-layer processing graph, separates
 time-indexed samples from record/literal provenance, freezes package-mode
 nullability and scalar encodings, and binds terminal mass to a realized shot
 event. The task remains non-commissioning.
+The compatibility-serialization closure reconciles typed resource members,
+defines a sealed metadata envelope distinct from a Puckworks submission,
+freezes row and nested-field ordering, maps local provenance to Puckworks
+`raw`/`processed`, and removes recursive manifest dependencies. Review remains
+pending and commissioning remains unauthorized.
 
 VAL-INFRA-002 is a merged reusable-infrastructure repair that scopes the
 legacy WP-0.3C Stage-0 verifier scope. It changes no scientific result,

--- a/docs/QA_STATUS.md
+++ b/docs/QA_STATUS.md
@@ -115,6 +115,9 @@ The final evidence/schema correction preserves that status while separating
 frozen parameter classifications from future roles, closing route/partition/
 replicate/block parents and foreign keys, and making the signal table the sole
 authority for measured pressure.
+The referential-integrity correction additionally verifies exact locked versus
+future-template parents, complete signal-sample references, globally unique
+resource keys, table-specific nullability, and composite consistency keys.
 
 ## WP-0.3C Stage-0 scaffold
 

--- a/docs/QA_STATUS.md
+++ b/docs/QA_STATUS.md
@@ -142,6 +142,10 @@ The compatibility-serialization audit additionally verifies closed typed
 resource-member mappings, sealed-envelope schemas and non-submission status,
 canonical YAML/CSV ordering and field paths, exact `raw`/`processed` mappings,
 and nonrecursive file/package manifests. It performs no evidence validation.
+The state-and-serialization audit additionally verifies all four package
+modes, disjoint full/sealed operation branches, reachable status values,
+total row-state mapping, byte-deterministic apparatus calibration YAML, and
+exact equality between package-QA and source-manifest identities.
 
 ## WP-0.3C Stage-0 scaffold
 

--- a/docs/QA_STATUS.md
+++ b/docs/QA_STATUS.md
@@ -128,6 +128,11 @@ terminal rights, distinct row-value and file-assembly operations, and exact
 synchronized-time-series and terminal-mass selection rules. The deterministic
 schema/export audit is required before commissioning readiness; commissioning
 is not authorized here.
+The final machine-contract audit additionally covers every identifier and
+resource field, package/partition identity and summary reconciliation,
+registered temperature export, exact and two-sample source provenance,
+fraction/chemistry package state, and exactly-one-grid/export-operation
+cardinality. No scientific or experimental execution is part of this check.
 
 ## WP-0.3C Stage-0 scaffold
 

--- a/docs/QA_STATUS.md
+++ b/docs/QA_STATUS.md
@@ -111,6 +111,10 @@ future evidence route prospective, fixes prescribed pressure at the basket-top
 node, and adds parameter-role, data-schema, timing, and deformation contracts.
 `EXPERIMENTAL_COMMISSIONING: NOT_AUTHORIZED`, VAL-CASE-002 remains
 `NOT_STARTED`, and physical validation remains `NOT_ESTABLISHED`.
+The final evidence/schema correction preserves that status while separating
+frozen parameter classifications from future roles, closing route/partition/
+replicate/block parents and foreign keys, and making the signal table the sole
+authority for measured pressure.
 
 ## WP-0.3C Stage-0 scaffold
 

--- a/docs/QA_STATUS.md
+++ b/docs/QA_STATUS.md
@@ -121,6 +121,13 @@ resource keys, table-specific nullability, and composite consistency keys.
 The template-interface correction further records noncontradictory source-file
 nullability, local/catalog campaign namespaces, field-level compatibility
 exports, and multi-file processing lineage.
+The implementation-contract closure adds exact apparatus/signal/calibration
+bindings, a fraction parent and deterministic chemistry presentation,
+partition-specific compatibility packages, typed canonical resources with
+terminal rights, distinct row-value and file-assembly operations, and exact
+synchronized-time-series and terminal-mass selection rules. The deterministic
+schema/export audit is required before commissioning readiness; commissioning
+is not authorized here.
 
 ## WP-0.3C Stage-0 scaffold
 

--- a/docs/QA_STATUS.md
+++ b/docs/QA_STATUS.md
@@ -105,6 +105,12 @@ VAL-DATA-001 adds only an append-only campaign-reference erratum and a
 non-commissioning synchronized hydraulic-compaction measurement plan. It
 changes no result, code, configuration, framework, standard, dependency, or
 physics and performs no scientific or experimental execution.
+The bounded planning correction records
+`VAL_DATA_001_REVIEW_STATUS: CORRECTED_PENDING_EXACT_HEAD_REVIEW`, makes the
+future evidence route prospective, fixes prescribed pressure at the basket-top
+node, and adds parameter-role, data-schema, timing, and deformation contracts.
+`EXPERIMENTAL_COMMISSIONING: NOT_AUTHORIZED`, VAL-CASE-002 remains
+`NOT_STARTED`, and physical validation remains `NOT_ESTABLISHED`.
 
 ## WP-0.3C Stage-0 scaffold
 

--- a/docs/QA_STATUS.md
+++ b/docs/QA_STATUS.md
@@ -133,6 +133,11 @@ resource field, package/partition identity and summary reconciliation,
 registered temperature export, exact and two-sample source provenance,
 fraction/chemistry package state, and exactly-one-grid/export-operation
 cardinality. No scientific or experimental execution is part of this check.
+The final export-contract audit additionally verifies conversion-domain
+separation, mutually exclusive processing scopes, record/sample/literal
+provenance, package content-mode nullability, byte-reproducible Puckworks
+scalars, realized termination-event linkage, edge ordering, filenames, row
+keys, row state, and campaign/site/apparatus consistency.
 
 ## WP-0.3C Stage-0 scaffold
 

--- a/docs/QA_STATUS.md
+++ b/docs/QA_STATUS.md
@@ -99,6 +99,13 @@ transfer, or introduce runtime extraction physics.
 
 Physical validation remains `NOT_ESTABLISHED`.
 
+## VAL-DATA-001 planning candidate
+
+VAL-DATA-001 adds only an append-only campaign-reference erratum and a
+non-commissioning synchronized hydraulic-compaction measurement plan. It
+changes no result, code, configuration, framework, standard, dependency, or
+physics and performs no scientific or experimental execution.
+
 ## WP-0.3C Stage-0 scaffold
 
 WP-0.3C Stage 0 remains a completed, frozen scaffold. Requirements,

--- a/docs/QA_STATUS.md
+++ b/docs/QA_STATUS.md
@@ -118,6 +118,9 @@ authority for measured pressure.
 The referential-integrity correction additionally verifies exact locked versus
 future-template parents, complete signal-sample references, globally unique
 resource keys, table-specific nullability, and composite consistency keys.
+The template-interface correction further records noncontradictory source-file
+nullability, local/catalog campaign namespaces, field-level compatibility
+exports, and multi-file processing lineage.
 
 ## WP-0.3C Stage-0 scaffold
 

--- a/docs/QA_STATUS.md
+++ b/docs/QA_STATUS.md
@@ -138,6 +138,10 @@ separation, mutually exclusive processing scopes, record/sample/literal
 provenance, package content-mode nullability, byte-reproducible Puckworks
 scalars, realized termination-event linkage, edge ordering, filenames, row
 keys, row state, and campaign/site/apparatus consistency.
+The compatibility-serialization audit additionally verifies closed typed
+resource-member mappings, sealed-envelope schemas and non-submission status,
+canonical YAML/CSV ordering and field paths, exact `raw`/`processed` mappings,
+and nonrecursive file/package manifests. It performs no evidence validation.
 
 ## WP-0.3C Stage-0 scaffold
 

--- a/docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md
+++ b/docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md
@@ -1,0 +1,212 @@
+# VAL-DATA-001 synchronized hydraulic-compaction measurement plan
+
+**Task class:** `EXPERIMENTAL_DESIGN_AND_DATA_REQUEST_PLANNING`  
+**Change declaration:** `NO_GOVERNING_PHYSICS_CHANGE`  
+**Status:** `COMMISSIONING_NOT_AUTHORIZED`  
+**Evidence class intended for a future separately authorized case:**
+`INDEPENDENT_COMPONENT_VALIDATION`  
+**Claim ceiling:** `VALIDATION_SUPPORT_ONLY_PHYSICAL_VALIDATION_NOT_ESTABLISHED`
+
+This document is an implementation-ready planning input for a later human
+commissioning decision. It does not authorize procurement, apparatus work,
+data collection, calibration execution, model fitting, scoring, or a
+validation case.
+
+## Scientific questions and decisions enabled
+
+The future package should determine whether synchronized pressure, flow/mass,
+and deformation distinguish hydraulic resistance from compaction response;
+whether the existing universal and finite-porosity branches produce resolvable
+differences; which machine-side parameters remain practically confounded; and
+whether an independently held-out dataset can support a bounded component
+comparison. Results may support parameter/model-form discrimination or show
+that additional data are required. A governing-physics increment would be
+considered only after reproducible, uncertainty-aware residual structure
+remains across independent conditions and cannot be explained by preparation,
+apparatus, boundary-node, calibration, or existing-model uncertainty. A fit
+improvement alone would not justify new physics.
+
+## Campaign crosswalk
+
+| Measurement need | Puckworks campaign | Coverage |
+|---|---|---|
+| Basket pressure, outlet flow/mass, temperature, cup chemistry | EXP-001 — Synchronized whole-shot telemetry and cup chemistry | Partial/core whole-shot telemetry |
+| Physical first drip and initially dry infiltration | EXP-002 — Initially dry puck infiltration and physical first drip | Optional high-value wetting package |
+| PSD, fines fraction, packing, porosity, permeability | EXP-003 — Grinder-specific particle-size, packing, and permeability map | Required input-characterization support |
+| Deformation, pressure, flow | EXP-004 — Poroelastic deformation, pressure, and flow | Principal compaction-discrimination campaign |
+| Time-dependent swelling/coupled-bed discrimination | EXP-005 — Time-dependent bed-mechanism discrimination (`kappa(t)`) | Deferred; not minimum package |
+| Separate upstream machine-side pressure and machine response | No complete current campaign | `PUCKWORKS_MACHINE_MODE_CAMPAIGN_GAP` |
+
+Future human disposition may extend EXP-001, extend EXP-004, define a new
+Puckworks campaign, or retain an espresso-whole-pull-specific extension. None
+is selected or commissioned here. EXP-001 through EXP-004 do not collectively
+establish complete upstream machine-pressure coverage.
+
+## Apparatus and physical nodes
+
+The apparatus record must identify machine, hydraulic circuit, basket, coffee
+bed, outlet collection, deformation reference, and every sensor location.
+Four nodes are distinct and must never be substituted:
+
+1. `P_MACHINE_UPSTREAM_RU_PA_GAUGE`: machine-side gauge pressure upstream of
+   the declared upstream resistance `Ru`.
+2. `P_BASKET_BED_TOP_PA_GAUGE`: basket pressure at the coffee-bed top.
+3. `OUTLET_FLOW_ML_S` and `DELIVERED_MASS_G`: basket-bottom outlet flow and
+   cumulative collected mass.
+4. `BED_HEIGHT_MM` or `DEFORMATION_MM`: displacement relative to a declared
+   unloaded/reference bed-height basis and spatial location.
+
+Pressure sign is positive above ambient gauge pressure; outlet flow and mass
+are positive leaving the basket; compression/deformation sign must be declared
+once and retained. Temperature uses degrees Celsius with sensor location.
+Physical first drip is elapsed time from the common shot origin to independently
+detected physical liquid at the defined outlet plane.
+
+## Minimum condition matrix
+
+| Condition | Status | Control and measured nodes | Required role fields |
+|---|---|---|---|
+| Prescribed 5 bar | Required | prescribed boundary target; independently measured basket-top pressure, outlet flow/mass, and deformation | preparation, common origin, calibration state, replicate/block ID, comparison/holdout role |
+| Prescribed 9 bar | Required | same nodes and metadata as 5 bar | primary mid-range discrimination condition |
+| Machine-coupled shot | Required | measured machine-side pressure upstream of `Ru` and separate basket-top pressure, outlet flow/mass, deformation | machine response plus all common metadata |
+| Prescribed 11 bar | Optional model-form stress condition | same prescribed-condition nodes | must not be treated as sufficient alone for local compaction discrimination |
+
+Actual control accuracy and apparatus feasibility remain
+`APPARATUS_FEASIBILITY_REQUIRED`. Every run must bind its condition ID,
+replicate ID, randomized order, preparation block, sensor/calibration IDs, and
+predeclared comparison or holdout role.
+
+## Model-informed signal targets
+
+Every value below is
+`MODEL_INFORMED_FUTURE_DESIGN_TARGET_NOT_VALIDATION_THRESHOLD` (also the
+short-form planning class `MODEL_INFORMED_FUTURE_DESIGN_TARGET`). It is not a
+validated threshold, acceptance gate, demonstrated uncertainty, feasibility
+claim, or procurement specification.
+
+| Signal | Model-informed future design target | Resolution status |
+|---|---:|---|
+| Basket-top pressure | approximately <= 8 kPa | `SENSOR_SELECTION_REQUIRED`; `APPARATUS_FEASIBILITY_REQUIRED` |
+| Machine-side pressure upstream of `Ru` | approximately <= 8 kPa | `SENSOR_SELECTION_REQUIRED`; campaign gap |
+| Basket-bottom outlet flow | approximately <= 0.02 mL/s | `SENSOR_SELECTION_REQUIRED`; `PILOT_REQUIRED` |
+| Cumulative delivered mass | approximately <= 0.5 g | `SENSOR_SELECTION_REQUIRED`; `PILOT_REQUIRED` |
+| Bed height/deformation | approximately <= 0.05 mm | `SENSOR_SELECTION_REQUIRED`; `APPARATUS_FEASIBILITY_REQUIRED` |
+| Common synchronization/raw sampling | approximately <= 20 ms | latency study required |
+| Optional physical first drip | approximately <= 0.02 s | `SENSOR_SELECTION_REQUIRED`; `PILOT_REQUIRED` |
+
+## Metadata and preparation controls
+
+Record apparatus identifiers and revisions; hydraulic schematic and node
+coordinates; basket geometry and coffee-bed hydraulic area; dose, dry bed
+depth, post-preparation bed height, headspace, water temperature, ambient
+pressure, and relevant line temperature; coffee identity and rights status;
+roast and age metadata; grinder identity/settings; PSD/fines characterization;
+distribution, leveling, tamp protocol and force record; operator/automation
+role; timing; and deviations. Real values remain unresolved until authorized
+acquisition.
+
+## Timebase, calibration, and latency
+
+All raw channels require one monotonic elapsed-time basis with an explicit
+physical `t=0` event. If a single hardware clock is unavailable, retain native
+timestamps and document offset, drift, resampling, and latency characterization
+without overwriting raw data. Pre- and post-session calibration records,
+traceability, range, detection limit, hysteresis, drift, zeroing, cross-talk,
+dynamic response, alignment, and clock latency must be retained. Final sensor
+models and calibration procedures remain `SENSOR_SELECTION_REQUIRED`.
+
+## Uncertainty-budget headings
+
+The future uncertainty budget must separately cover calibration reference,
+resolution/quantization, repeatability, drift, latency and synchronization,
+dynamic response, spatial/node placement, temperature dependence, density
+conversion, collection/retention/evaporation, deformation reference and
+alignment, preparation variability, between-block variability, and processing
+effects. Numerical values require pilot and calibration evidence and remain
+`PILOT_REQUIRED`.
+
+## Pilot and replication design
+
+Pilot objectives are to demonstrate node accessibility, signal range,
+bandwidth, clock synchronization, safe operation, preparation repeatability,
+missingness/failure modes, and deformation-reference stability. They remain
+`PILOT_REQUIRED` and `COMMISSIONING_NOT_AUTHORIZED`.
+
+Final replicates are `DESIGN_CALCULATION_REQUIRED`. The later calculation must
+use pilot estimates of within-condition and between-block variance, the
+smallest predeclared discrimination contrast, desired interval width or power,
+multiple-condition structure, anticipated exclusions, and independent holdout
+allocation. It must document assumptions and sensitivity to them; this plan
+does not invent a replicate count or power value.
+
+Randomize condition order within feasible thermal/preparation blocks. Predefine
+blocks for day/session, coffee batch, grinder state, operator or automation
+state, and apparatus/calibration state. Record order and deviations. Never
+silently replace failed or excluded runs.
+
+## Data layout and integrity
+
+Retain separate checksum-bound areas:
+
+- `raw/`: immutable instrument-native files and calibration outputs;
+- `processed/`: synchronized, unit-normalized, quality-flagged signals with
+  transformation provenance;
+- `derived/`: declared features, uncertainty propagation, comparisons, and
+  figures.
+
+Provide a data dictionary containing signal name, physical definition, units,
+sign, node/spatial basis, native clock, sampling, missing-value code,
+calibration ID, and processing lineage. Preserve all replicates and all failed
+or excluded runs with reason codes. Never smooth, overwrite, or replace raw
+files. Distinguish prescribed targets from measured quantities.
+
+## Quality control, failures, and exclusions
+
+Predeclare checks for clock monotonicity, dropped/duplicate samples, saturation,
+range, zero/reference drift, calibration validity, sensor-node identity,
+collection continuity, mass monotonicity where physically applicable,
+deformation reference, metadata completeness, and protocol deviations.
+Equipment failure, invalid calibration, lost synchronization, wrong condition,
+or documented preparation failure may exclude a run only under a preregistered
+rule. Preserve the run, raw files, flags, and rationale. Scientific disagreement
+is never an exclusion reason.
+
+## Preregistered analysis, fitting separation, and holdout
+
+Before access to comparison outcomes, preregister time origin, filtering and
+resampling, feature definitions, uncertainty propagation, missingness,
+exclusions, parameter/model-form metrics, thresholds, and interpretation.
+Separate prescribed quantities, independently measured inputs, calibration
+quantities, comparison outputs, contextual metadata, and excluded quantities.
+
+Allocate holdout units or blocks before fitting and seal their identities and
+files. Calibration and model selection must not use holdout observations.
+Holdout access and scoring require separate authority; they are not authorized
+here. Downstream decisions must distinguish inadequate measurement information,
+parameter confounding, model-form discrimination, and persistent structured
+residuals.
+
+## Rights, privacy, and deposit
+
+Before commissioning, document ownership, participant/operator privacy,
+apparatus confidentiality, redistribution license, source rights, consent where
+applicable, embargo, public/private field partition, and repository destination.
+Deposit must include checksums, immutable raw files, processed/derived lineage,
+data dictionary, protocols, calibration records, exclusions, software identity,
+and citation metadata. Rights must permit the intended independent comparison.
+
+## Commissioning-readiness checklist
+
+- [ ] Human owner issues separate commissioning authority.
+- [ ] Machine-mode campaign gap receives a documented human disposition.
+- [ ] Apparatus and node feasibility: `APPARATUS_FEASIBILITY_REQUIRED`.
+- [ ] Sensors and calibration chain: `SENSOR_SELECTION_REQUIRED`.
+- [ ] Pilot protocol and evidence: `PILOT_REQUIRED`.
+- [ ] Replication and holdout calculation: `DESIGN_CALCULATION_REQUIRED`.
+- [ ] Randomization, blocks, exclusions, and preregistered analysis frozen.
+- [ ] Rights, privacy, custody, and deposit plan accepted.
+- [ ] Safety and operational review accepted by responsible humans.
+- [ ] Evidence roles and claim ceiling recorded.
+
+Until every required item is resolved, status remains
+`COMMISSIONING_NOT_AUTHORIZED`.

--- a/docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md
+++ b/docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md
@@ -190,18 +190,23 @@ Numeric zero is never a missing-value code.
 | `val_data_001_evidence_partitions.csv` | `evidence_partition_id` | `evidence_partition_id`, `campaign_instance_id`, `route_id`, `analysis_role`, `evidence_class`, `sealed_status`, `partition_manifest_sha256`, `seal_timestamp_utc`, `custodian_resource_id`, `access_policy_resource_id`, `rights_resource_id` |
 | `val_data_001_replicates.csv` | `replicate_id` | `replicate_id`, `campaign_instance_id`, `route_id`, `condition_id`, `block_id`, `replicate_sequence`, `randomization_sequence`, `evidence_partition_id` |
 | `val_data_001_blocks.csv` | `block_id` | `block_id`, `campaign_instance_id`, `block_type`, `block_label`, `session_start_utc`, `coffee_lot_resource_id`, `grinder_state_resource_id`, `operator_role_resource_id`, `apparatus_state_resource_id`, `calibration_set_id` |
-| `val_data_001_resources.csv` | `resource_id` (globally unique) | `resource_id`, `resource_type`, `definition`, `resource_provenance_mode`, `source_file_id`, `rights_resource_id` |
+| `val_data_001_resources.csv` | `resource_id` (globally unique) | `resource_id`, `resource_type`, `payload_schema_id`, `payload_json_canonical`, `resource_provenance_mode`, `source_file_id`, `rights_resource_id` |
+| `val_data_001_resource_type_schemas.csv` | `payload_schema_id` | `payload_schema_id`, `resource_type`, `schema_version`, `required_members_json_canonical`, `optional_members_json_canonical`, `member_types_json_canonical`, `additional_members_allowed`, `schema_sha256` |
 | `val_data_001_conditions.csv` | `condition_id` | `condition_id`, `campaign_instance_id`, `apparatus_id`, `control_mode`, `prescribed_node`, `prescribed_pressure_pa_gauge`, `command_program_resource_id`, `initial_hydraulic_state_resource_id`, `ambient_reference_pa`, `zeroing_basis`, `ramp_definition`, `plateau_definition`, `termination_rule`, `control_tolerance_pa`, `missing_value_state` |
 | `val_data_001_shots.csv` | `shot_id` | `shot_id`, `campaign_instance_id`, `route_id`, `condition_id`, `apparatus_id`, `replicate_id`, `block_id`, `evidence_partition_id`, `coffee_lot_resource_id`, `grinder_resource_id`, `basket_resource_id`, `dose_g`, `dry_bed_depth_mm`, `preparation_protocol_resource_id`, `target_beverage_g`, `brew_temperature_c`, `raw_or_processed`, `inclusion_status`, `exclusion_reason`, `t0_event_code`, `t0_uncertainty_s` |
-| `val_data_001_signals.csv` | (`shot_id`, `signal_id`, `sample_index`) | `shot_id`, `signal_id`, `sample_index`, `sensor_resource_id`, `clock_resource_id`, `calibration_id`, `source_file_id`, `processing_id`, `native_timestamp`, `elapsed_time_s`, `native_value`, `native_unit`, `canonical_value`, `canonical_unit`, `physical_node`, `raw_or_processed`, `quality_flags`, `missing_value_state`, `clock_offset_s`, `clock_drift_s_per_s`, `sensor_latency_s`, `resampling_interval_s` |
-| `val_data_001_controls.csv` | (`shot_id`, `control_sample_index`) | `shot_id`, `control_sample_index`, `command_program_resource_id`, `clock_resource_id`, `source_file_id`, `processing_id`, `raw_or_processed`, `native_timestamp`, `elapsed_time_s`, `commanded_pressure_value`, `commanded_pressure_unit`, `prescribed_node`, `basket_pressure_signal_id`, `basket_pressure_sample_index`, `upstream_pressure_signal_id`, `upstream_pressure_sample_index`, `upstream_pressure_availability`, `control_deviation_pa`, `control_status`, `control_phase` |
-| `val_data_001_flow_conversions.csv` | `conversion_id` | `conversion_id`, `shot_id`, `density_source_resource_id`, `calibration_id`, `calibration_applicability`, `source_file_id`, `native_mass_flow_g_s`, `native_volume_flow_ml_s`, `canonical_mass_flow_kg_s`, `canonical_volume_flow_m3_s`, `density_kg_m3`, `density_temperature_c`, `conversion_formula`, `processing_id` |
-| `val_data_001_deformation.csv` | (`shot_id`, `location_id`, `sample_index`) | `shot_id`, `location_id`, `sample_index`, `sensor_resource_id`, `calibration_id`, `reference_state_resource_id`, `fixture_compliance_resource_id`, `source_file_id`, `processing_id`, `raw_or_processed`, `native_timestamp`, `elapsed_time_s`, `native_displacement_value`, `native_displacement_unit`, `canonical_displacement_m`, `compression_sign`, `spatial_basis`, `axial_coordinate_m`, `radial_coordinate_m`, `coffee_bed_displacement_m`, `quality_flags`, `missing_value_state` |
-| `val_data_001_chemistry.csv` | (`shot_id`, `fraction_id`, `species`) | `shot_id`, `fraction_id`, `species`, `mass_mg`, `reference_basis`, `analytical_method_resource_id`, `detection_limit_mg`, `recovery_pct`, `measurement_status`, `source_file_id`, `processing_id` |
+| `val_data_001_signals.csv` | (`shot_id`, `signal_id`, `sample_index`) | `shot_id`, `apparatus_id`, `signal_id`, `sample_index`, `sensor_resource_id`, `clock_resource_id`, `calibration_id`, `source_file_id`, `value_processing_id`, `native_timestamp`, `elapsed_time_s`, `native_value`, `native_unit`, `canonical_value`, `canonical_unit`, `physical_node`, `raw_or_processed`, `quality_flags`, `missing_value_state`, `clock_offset_s`, `clock_drift_s_per_s`, `sensor_latency_s`, `resampling_interval_s` |
+| `val_data_001_controls.csv` | (`shot_id`, `control_sample_index`) | `shot_id`, `control_sample_index`, `command_program_resource_id`, `clock_resource_id`, `source_file_id`, `value_processing_id`, `raw_or_processed`, `native_timestamp`, `elapsed_time_s`, `commanded_pressure_value`, `commanded_pressure_unit`, `prescribed_node`, `basket_pressure_signal_id`, `basket_pressure_sample_index`, `upstream_pressure_signal_id`, `upstream_pressure_sample_index`, `upstream_pressure_availability`, `control_deviation_pa`, `control_status`, `control_phase` |
+| `val_data_001_flow_conversions.csv` | `conversion_id` | `conversion_id`, `shot_id`, `density_source_resource_id`, `calibration_id`, `calibration_applicability`, `source_file_id`, `native_mass_flow_g_s`, `native_volume_flow_ml_s`, `canonical_mass_flow_kg_s`, `canonical_volume_flow_m3_s`, `density_kg_m3`, `density_temperature_c`, `conversion_formula`, `value_processing_id` |
+| `val_data_001_deformation.csv` | (`shot_id`, `location_id`, `sample_index`) | `shot_id`, `apparatus_id`, `signal_id`, `location_id`, `sample_index`, `sensor_resource_id`, `clock_resource_id`, `calibration_id`, `reference_state_resource_id`, `fixture_compliance_resource_id`, `source_file_id`, `value_processing_id`, `raw_or_processed`, `native_timestamp`, `elapsed_time_s`, `native_displacement_value`, `native_displacement_unit`, `canonical_displacement_m`, `compression_sign`, `spatial_basis`, `axial_coordinate_m`, `radial_coordinate_m`, `coffee_bed_displacement_m`, `quality_flags`, `missing_value_state` |
+| `val_data_001_fractions.csv` | (`shot_id`, `fraction_id`) | `shot_id`, `fraction_id`, `evidence_partition_id`, `fraction_start_s`, `fraction_end_s`, `fraction_mass_g`, `fraction_tds_pct`, `raw_or_processed`, `source_file_id`, `value_processing_id`, `fraction_state` |
+| `val_data_001_chemistry.csv` | (`shot_id`, `fraction_id`, `species`) | `shot_id`, `fraction_id`, `evidence_partition_id`, `species`, `mass_mg`, `reference_basis`, `analytical_method_resource_id`, `detection_limit_mg`, `recovery_pct`, `measurement_status`, `source_file_id`, `value_processing_id` |
 | `val_data_001_calibrations.csv` | `calibration_id` | `calibration_id`, `calibration_set_id`, `apparatus_id`, `sensor_resource_id`, `source_file_id`, `observable_code`, `native_unit`, `canonical_unit`, `calibration_method`, `reference_resource_id`, `calibration_timestamp_utc`, `offset`, `scale`, `range_min`, `range_max`, `resolution`, `bandwidth_hz`, `latency_s`, `drift_per_s`, `uncertainty_resource_id`, `valid_from_utc`, `valid_to_utc` |
-| `val_data_001_files.csv` | `source_file_id` | `source_file_id`, `parent_source_file_id`, `relative_filename`, `file_role`, `raw_or_processed`, `sha256`, `byte_count`, `media_type`, `rights_resource_id`, `creator_software_resource_id`, `campaign_instance_id` |
-| `val_data_001_processing_operations.csv` | `processing_id` | `processing_id`, `software_commit`, `software_tree`, `operation_resource_id`, `parameter_record`, `synchronization_method`, `resampling_method`, `operator_role_resource_id`, `processing_timestamp_utc` |
+| `val_data_001_files.csv` | `source_file_id` | `source_file_id`, `relative_filename`, `file_role`, `raw_or_processed`, `sha256`, `byte_count`, `media_type`, `rights_resource_id`, `creator_software_resource_id`, `campaign_instance_id`, `evidence_partition_id` |
+| `val_data_001_processing_operations.csv` | `processing_id` | `processing_id`, `operation_scope`, `software_commit`, `software_tree`, `operation_resource_id`, `parameter_record_json_canonical`, `synchronization_method`, `resampling_method`, `operator_role_resource_id`, `processing_timestamp_utc` |
 | `val_data_001_processing_file_edges.csv` | (`processing_id`, `edge_role`, `source_file_id`) | `processing_id`, `edge_role`, `source_file_id`, `edge_sequence`, `channel_or_output_role` |
+| `val_data_001_compatibility_packages.csv` | `compatibility_package_id` | `compatibility_package_id`, `campaign_instance_id`, `route_id`, `evidence_partition_id`, `puckworks_campaign_id`, `access_policy_resource_id`, `rights_resource_id`, `package_access_status`, `package_evidence_class`, `package_manifest_sha256`, `assembly_processing_id`, `export_status` |
+| `val_data_001_export_grids.csv` | `export_grid_id` | `export_grid_id`, `compatibility_package_id`, `grid_start_s`, `grid_end_s`, `resampling_interval_s`, `alignment_tolerance_s`, `basket_pressure_rule`, `delivered_mass_rule`, `flow_rule`, `temperature_rule`, `missing_value_rule`, `grid_freeze_resource_id` |
+| `val_data_001_export_source_rows.csv` | (`compatibility_package_id`, `export_filename`, `export_row_key`, `export_field`) | `compatibility_package_id`, `export_filename`, `export_row_key`, `export_field`, `source_table`, `source_key_json_canonical`, `conversion_id`, `value_processing_id`, `export_processing_id` |
 
 The locked Puckworks bindings distinguish immutable schemas from future data.
 `campaign_instance_id` is the authoritative local identifier for one
@@ -234,6 +239,119 @@ extension must not claim Puckworks submission compatibility until a valid
 catalog campaign is prospectively selected or created under separate
 authority.
 
+### Implementation-contract closure
+
+The following rules are normative and replace any less-specific schema prose
+in this document.
+
+#### Signal-registry and calibration binding
+
+Every signal and deformation row carries `apparatus_id` and resolves both
+`(shot_id, apparatus_id)` to the shot candidate key and
+`(apparatus_id, signal_id)` to `val_data_001_apparatus_signals.csv`. The row's
+`sensor_resource_id`, observable or physical node, native unit, and clock must
+equal the registry entry. Raw rows use the registered native clock and unit;
+processed rows retain their raw input through the processing-edge graph and
+identify the synchronized clock and value-producing operation.
+
+Calibration nullability is controlled solely by the registry's
+`calibration_applicability`, never by sample missingness. `APPLICABLE` requires
+one calibration whose apparatus, sensor, observable, native unit, calibration
+set, and validity interval cover the acquisition time. `NOT_APPLICABLE`
+requires null. `UNKNOWN_PENDING_REVIEW` requires null and blocks commissioning
+readiness. A missing or failed sample does not relax these rules. Deformation
+uses the same registry and calibration rules and additionally requires its
+reference-state and fixture-compliance resources.
+
+#### Fraction parent and locked chemistry export
+
+`val_data_001_fractions.csv` is the parent of chemistry rows. Chemistry
+resolves `(shot_id, fraction_id)` to that table, and its
+`evidence_partition_id` must equal the fraction and shot partition. When
+fraction chemistry is acquired, `fraction_metadata.csv` is generated exactly
+with columns `campaign_id,shot_id,fraction_id,fraction_start_s,
+fraction_end_s,fraction_mass_g,fraction_tds_pct,raw_or_processed`;
+`campaign_id` is the mapped Puckworks campaign ID and every other value comes
+from the fraction parent. When absent, the package records
+`NOT_APPLICABLE_NO_FRACTIONATED_CHEMISTRY`; it must not fabricate fraction or
+chemistry rows.
+
+#### Typed resources and terminal rights
+
+`payload_json_canonical` conforms to `payload_schema_id` for the declared
+`resource_type`. Canonical serialization is UTF-8 JSON with lexicographically
+sorted object keys, no insignificant whitespace, JSON `null` only where the
+type schema permits it, finite base-10 numbers, and no duplicate keys.
+Required payload members are: `CONTRIBUTOR{name,role}`;
+`EXTERNAL_REPOSITORY{repository,doi}`; `RIGHTS{license,access_class,
+redistribution_status}`; `SENSOR{manufacturer,model,serial_or_asset_id}`;
+`CLOCK{clock_id,clock_basis}`; `UNCERTAINTY{status,budget_resource_ids}`;
+machine, grinder, burr, basket, and grinder-setting resources
+`{identity,definition}`; command, preparation, reference, density, and
+operation resources `{method,version,parameters}`; and all remaining
+enumerated types `{definition,status}`. Unresolved real-world values use the
+applicable controlled unresolved disposition, not invented values.
+Every used `payload_schema_id` resolves to
+`val_data_001_resource_type_schemas.csv`; the schema row's `resource_type`
+must match, `additional_members_allowed=false`, and its canonical required,
+optional, and member-type maps make the payload contract complete rather than
+prose-extensible. The schema hash is verified before package assembly.
+
+A `RIGHTS` resource is terminal: its `rights_resource_id` and
+`source_file_id` are null, and its payload carries its own provenance and
+rights assertion. Every non-rights resource and file has exactly one direct
+reference to a terminal `RIGHTS` resource, including public-domain material.
+Self-references, rights-to-rights references, and rights-reference cycles are
+invalid.
+
+#### Partition-specific compatibility packages
+
+Each compatibility package belongs to exactly one evidence partition. A
+package cannot combine rows, files, manifests, or exports from partitions
+with different access or evidence roles. For Route B, calibration and sealed
+scoring evidence are always separate packages; before authorized opening, a
+sealed package may expose only its seal identity, rights/access metadata, and
+checksum manifest, never observations or presentation exports. Package
+assembly fails if an input edge crosses the package partition. Routes A and C
+use the same one-partition-per-package rule, with their route-specific access
+states. This prevents compatibility presentation from becoming an access
+side channel.
+
+#### Row-value and file-assembly lineage
+
+`operation_scope` is exactly `ROW_VALUE`, `NORMALIZED_FILE_ASSEMBLY`, or
+`COMPATIBILITY_EXPORT`. A row's `value_processing_id` references only a
+`ROW_VALUE` operation and is null only for a directly reported raw native
+value. File assembly and compatibility export operations never masquerade as
+row-value transformations. `parent_source_file_id` is not part of the files
+schema and is not authoritative. All actual dependencies use
+`processing_file_edges`; every processed or derived file has exactly one
+output producer, every producer has at least one input and one output, native
+files have no output producer, and the bipartite file-operation graph is
+acyclic. Compatibility packages reference their single assembly operation,
+and every export source row references its export operation.
+
+#### Exact synchronized-time-series and terminal-mass export
+
+Every `shot_timeseries.csv` package uses one frozen `export_grid_id`. Its grid
+start, end, interval, alignment tolerance, per-observable selection or
+interpolation rule, and missing-value behavior are explicit. Export rows are
+ordered by `(shot_id, elapsed_s)`; each field records a complete canonical
+source key in `val_data_001_export_source_rows.csv`. Exact samples are used
+when present. Otherwise interpolation is allowed only by the frozen rule,
+within tolerance, between two quality-eligible samples; extrapolation is
+prohibited. Missing values remain empty with an explicit quality disposition.
+Pressure is the basket-top Pa-gauge value divided by exactly 100000; upstream
+pressure is not substituted. Conversions and processing identities are
+retained.
+
+`achieved_beverage_g` uses the last quality-eligible `DELIVERED_MASS_G` sample
+at or before the prospectively frozen termination event. Ties resolve by the
+largest `sample_index`. The exact signal primary key and conversion are
+retained. If the termination event or eligible mass sample is absent, the
+value is empty and the shot receives a deterministic exclusion or QC status;
+target mass or a later sample is never substituted.
+
 ### Deterministic Puckworks compatibility exports
 
 The normalized VAL-DATA-001 tables are authoritative. Locked Puckworks
@@ -248,7 +366,7 @@ commissioning readiness. Export is prohibited unless
 |---|---|
 | `campaign_metadata.yml.campaign_id` | `campaigns.puckworks_campaign_id` |
 | `.site_id` | `campaigns.site_id` |
-| `.contributor` | `resources.definition` for `campaigns.contributor_resource_id` |
+| `.contributor` | typed canonical payload for `campaigns.contributor_resource_id` |
 | `.dataset_status` | `proposal_only` before acquisition; otherwise `pilot_collected` for pilot-only partitions, `holdout_reserved` for unopened Route-B scoring partitions, and `controlled_dataset` for other controlled acquired partitions |
 | `.evidence_level_claimed` | `feasibility_pilot` for pilot evidence; `controlled_replicated` for controlled comparison/calibration; `holdout_independent` only for an authorized opened Route-B score; no upgrade is implied |
 | `.external_repository`, `.doi` | exact `external_repository` and `doi` members of the `EXTERNAL_REPOSITORY` resource referenced by `campaigns.external_repository_resource_id` |
@@ -256,22 +374,22 @@ commissioning readiness. Export is prohibited unless
 | `.timezone` | `campaigns.timezone` |
 | `.replicate_count` | count of distinct `replicates.replicate_id` for `campaign_instance_id` |
 | `.exclusions_recorded` | boolean existence of excluded shots for the instance, reconciled with exported `exclusions.csv` |
-| `.deviations_from_protocol` | `resources.definition` for `campaigns.deviations_resource_id` |
+| `.deviations_from_protocol` | typed canonical payload for `campaigns.deviations_resource_id` |
 | `.declaration.*` | literal `true` only after the corresponding rights and no-upgrade assertions are verified; otherwise export is prohibited |
 
 | `apparatus.yml` field | Authoritative normalized source |
 |---|---|
 | `apparatus_id` | `apparatus.apparatus_id` |
-| `machine_make_model`, `grinder_make_model`, `burr_geometry`, `burr_wear_state`, `basket_geometry` | `resources.definition` from the correspondingly named apparatus resource field |
+| `machine_make_model`, `grinder_make_model`, `burr_geometry`, `burr_wear_state`, `basket_geometry` | typed canonical payload from the correspondingly named apparatus resource field |
 | `signals[].observable` | `apparatus_signals.observable_code` |
-| `signals[].instrument` | `resources.definition` for `apparatus_signals.sensor_resource_id` |
+| `signals[].instrument` | typed canonical sensor payload for `apparatus_signals.sensor_resource_id` |
 | `signals[].native_unit` | `apparatus_signals.native_unit` |
 | `signals[].native_sampling_rate` | reciprocal of `apparatus_signals.native_sample_interval_s`, with the operation and conversion retained |
 | `signals[].calibration` | calibration IDs linked to the signal; `NOT_APPLICABLE` only when `calibration_applicability=NOT_APPLICABLE` |
-| `signals[].uncertainty` | `resources.definition` for `apparatus_signals.uncertainty_resource_id` |
-| `signals[].clock_source` | `resources.definition` for `apparatus_signals.clock_resource_id` |
+| `signals[].uncertainty` | typed canonical payload for `apparatus_signals.uncertainty_resource_id` |
+| `signals[].clock_source` | typed canonical payload for `apparatus_signals.clock_resource_id` |
 | `signals[].synchronization_method` | `apparatus_signals.synchronization_method` |
-| `signals[].offset_drift_estimate` | `resources.definition` for `apparatus_signals.offset_drift_resource_id` |
+| `signals[].offset_drift_estimate` | typed canonical payload for `apparatus_signals.offset_drift_resource_id` |
 | `signals[].prescribed_or_measured` | `apparatus_signals.prescribed_or_measured` |
 
 | `shot_metadata.csv` field | Authoritative normalized source |
@@ -281,7 +399,7 @@ commissioning readiness. Export is prohibited unless
 | `coffee_lot_id`, `grinder_id`, `basket_id` | exact resource IDs from the shot |
 | `shot_id`, `replicate_id`, `dose_g`, `target_beverage_g`, `brew_temperature_c`, `raw_or_processed`, `exclusion_reason` | same-named authoritative shot fields |
 | `achieved_beverage_g` | authoritative final `DELIVERED_MASS_G` signal sample for the shot |
-| `grinder_setting` | exact `grinder_setting` member of `resources.definition` for `shots.grinder_resource_id` |
+| `grinder_setting` | exact `grinder_setting` member of the typed canonical payload for `shots.grinder_resource_id` |
 | `included` | `true` only for `inclusion_status=INCLUDED`; otherwise `false` |
 
 | `shot_timeseries.csv` field | Authoritative normalized source/conversion |
@@ -303,7 +421,8 @@ the locked `shot_timeseries.csv` has no upstream-pressure column.
 |---|---|
 | `calibration.csv` | `apparatus_id`, `observable`, `unit`, `calibration_datetime_utc`, `calibration_method`, `offset`, and `scale` come from same-named calibration fields (with `observable_code` and `native_unit` name mapping); `instrument` is the sensor resource definition; `notes` deterministically records range, resolution, bandwidth, latency, drift, uncertainty resource, validity interval, and calibration ID |
 | `exclusions.csv` | `campaign_id=campaigns.puckworks_campaign_id`; `shot_id` and `replicate_id` from the shot; `exclusion_reason` from the shot; `recorded_by` from the applicable operator-role resource |
-| `file_manifest.csv` | `filename=files.relative_filename`, `role=files.file_role`, `raw_or_processed`, `sha256`, and `bytes=byte_count`; `license` from the rights resource; `notes` deterministically records `source_file_id`, `parent_source_file_id`, `campaign_instance_id`, and producing processing edge if any |
+| `file_manifest.csv` | `filename=files.relative_filename`, `role=files.file_role`, `raw_or_processed`, `sha256`, and `bytes=byte_count`; `license` from the terminal rights resource; `notes` records `source_file_id`, `campaign_instance_id`, and the authoritative producing processing edge, if any |
+| `fraction_metadata.csv` | exact locked header; campaign mapping plus authoritative fraction-parent values, or package disposition `NOT_APPLICABLE_NO_FRACTIONATED_CHEMISTRY` |
 | `chemistry_measurements.csv` | when applicable, `campaign_id=campaigns.puckworks_campaign_id`; `shot_id`, `fraction_id`, `species`, `mass_mg`, `reference_basis`, `detection_limit_mg`, `recovery_pct`, and `measurement_status` from chemistry; `analytical_method` from its resource. When no chemistry is acquired, the file is declared `NOT_APPLICABLE` and is not fabricated |
 
 ### Primary and candidate keys
@@ -315,21 +434,26 @@ the locked `shot_timeseries.csv` has no upstream-pressure column.
 | apparatus | (`apparatus_id`); candidate (`apparatus_id`, `site_id`) |
 | apparatus signals | (`apparatus_id`, `signal_id`) |
 | campaigns | (`campaign_instance_id`); candidate (`campaign_instance_id`, `route_id`); candidate (`campaign_instance_id`, `apparatus_id`) |
-| evidence partitions | (`evidence_partition_id`); candidate (`evidence_partition_id`, `campaign_instance_id`, `route_id`) |
+| evidence partitions | (`evidence_partition_id`); candidate (`evidence_partition_id`, `campaign_instance_id`); candidate (`evidence_partition_id`, `campaign_instance_id`, `route_id`) |
 | conditions | (`condition_id`); candidate (`condition_id`, `campaign_instance_id`, `apparatus_id`) |
 | blocks | (`block_id`); candidate (`block_id`, `campaign_instance_id`) |
 | replicates | (`replicate_id`); candidate (`replicate_id`, `campaign_instance_id`, `route_id`, `condition_id`, `block_id`, `evidence_partition_id`) |
 | shots | (`shot_id`); candidate (`shot_id`, `campaign_instance_id`, `route_id`, `condition_id`, `apparatus_id`, `replicate_id`, `block_id`, `evidence_partition_id`) |
 | resources | (`resource_id`) globally unique |
+| resource type schemas | (`payload_schema_id`); candidate (`payload_schema_id`, `resource_type`) |
 | signals | (`shot_id`, `signal_id`, `sample_index`) |
 | controls | (`shot_id`, `control_sample_index`) |
 | flow conversions | (`conversion_id`) |
 | deformation | (`shot_id`, `location_id`, `sample_index`) |
+| fractions | (`shot_id`, `fraction_id`) |
 | chemistry | (`shot_id`, `fraction_id`, `species`) |
 | calibrations | (`calibration_id`) |
 | files | (`source_file_id`) |
 | processing operations | (`processing_id`) |
 | processing file edges | (`processing_id`, `edge_role`, `source_file_id`) |
+| compatibility packages | (`compatibility_package_id`); candidate (`compatibility_package_id`, `campaign_instance_id`, `route_id`, `evidence_partition_id`) |
+| export grids | (`export_grid_id`); candidate (`export_grid_id`, `compatibility_package_id`) |
+| export source rows | (`compatibility_package_id`, `export_filename`, `export_row_key`, `export_field`) |
 
 ### Foreign-key resolution matrix
 
@@ -350,26 +474,29 @@ exactly one parent; `NULLABLE` states the sole permitted null condition.
 | `replicates.(evidence_partition_id, campaign_instance_id, route_id)` | `val_data_001_evidence_partitions.csv.(evidence_partition_id, campaign_instance_id, route_id)` | many-to-one, all `NOT NULL` |
 | `shots.(replicate_id, campaign_instance_id, route_id, condition_id, block_id, evidence_partition_id)` | corresponding six fields of the replicate candidate key | many-to-one, all `NOT NULL` |
 | `shots.(condition_id, campaign_instance_id, apparatus_id)` | condition candidate key | many-to-one, all `NOT NULL` |
-| `signals.shot_id`, `controls.shot_id`, `flow_conversions.shot_id`, `deformation.shot_id`, `chemistry.shot_id` | `val_data_001_shots.csv.shot_id` | many-to-one, `NOT NULL` |
+| `signals.shot_id`, `controls.shot_id`, `flow_conversions.shot_id`, `deformation.shot_id`, `fractions.shot_id`, `chemistry.shot_id` | `val_data_001_shots.csv.shot_id` | many-to-one, `NOT NULL` |
+| `signals.(shot_id, apparatus_id)`, `deformation.(shot_id, apparatus_id)` | `val_data_001_shots.csv.(shot_id, apparatus_id)` | many-to-one, both `NOT NULL` |
+| `signals.(apparatus_id, signal_id)`, `deformation.(apparatus_id, signal_id)` | `val_data_001_apparatus_signals.csv.(apparatus_id, signal_id)` | many-to-one, both `NOT NULL`; registry identity fields must agree |
 | `signals.source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one, `NOT NULL` |
 | `controls.source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one, `NOT NULL` |
 | `flow_conversions.source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one, `NOT NULL` |
 | `deformation.source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one, `NOT NULL` |
 | `chemistry.source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one, `NOT NULL` |
 | `calibrations.source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one, `NOT NULL` |
-| `files.parent_source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one; null only for an instrument-native root file |
-| `signals.calibration_id` | `val_data_001_calibrations.csv.calibration_id` | many-to-one; null only when `signals.missing_value_state=NOT_APPLICABLE` and the signal definition requires no calibration |
+| `signals.calibration_id`, `deformation.calibration_id` | `val_data_001_calibrations.csv.calibration_id` | governed by the referenced registry row's `calibration_applicability`; `APPLICABLE` requires a validity-covering calibration, `NOT_APPLICABLE` requires null, and `UNKNOWN_PENDING_REVIEW` requires null and blocks readiness |
 | `flow_conversions.calibration_id` | `val_data_001_calibrations.csv.calibration_id` | many-to-one; `NOT NULL` when `flow_conversions.calibration_applicability=APPLICABLE`; null when it is `NOT_APPLICABLE` or `UNKNOWN_PENDING_REVIEW`, with `UNKNOWN_PENDING_REVIEW` blocking readiness |
-| `deformation.calibration_id` | `val_data_001_calibrations.csv.calibration_id` | many-to-one; null only when `deformation.missing_value_state=NOT_APPLICABLE` and the declared deformation method requires no calibration |
-| `signals.processing_id` | `val_data_001_processing_operations.csv.processing_id` | many-to-one; null only when `signals.raw_or_processed=RAW_NATIVE` |
-| `controls.processing_id` | `val_data_001_processing_operations.csv.processing_id` | many-to-one; null only when `controls.raw_or_processed=RAW_NATIVE` and `controls.control_deviation_pa` is empty |
-| `flow_conversions.processing_id` | `val_data_001_processing_operations.csv.processing_id` | many-to-one, `NOT NULL` |
-| `deformation.processing_id` | `val_data_001_processing_operations.csv.processing_id` | many-to-one; null only when `deformation.raw_or_processed=RAW_NATIVE` and `coffee_bed_displacement_m` is empty; otherwise `NOT NULL` |
-| `chemistry.processing_id` | `val_data_001_processing_operations.csv.processing_id` | many-to-one; null only for a directly reported native chemistry measurement, otherwise `NOT NULL` |
+| `signals.value_processing_id`, `controls.value_processing_id`, `flow_conversions.value_processing_id`, `deformation.value_processing_id`, `fractions.value_processing_id`, `chemistry.value_processing_id` | `val_data_001_processing_operations.csv.processing_id` | parent must have `operation_scope=ROW_VALUE`; null only for a directly reported raw native value |
 | `processing_file_edges.processing_id` | `val_data_001_processing_operations.csv.processing_id` | many-to-one, `NOT NULL` |
 | `processing_file_edges.source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one, `NOT NULL` |
 | `controls.(shot_id, basket_pressure_signal_id, basket_pressure_sample_index)` | `val_data_001_signals.csv.(shot_id, signal_id, sample_index)` | many-to-one, complete reference `NOT NULL` |
 | `controls.(shot_id, upstream_pressure_signal_id, upstream_pressure_sample_index)` | `val_data_001_signals.csv.(shot_id, signal_id, sample_index)` | many-to-one; signal ID and sample index are both present or both absent, and both may be absent only when `controls.upstream_pressure_availability=NOT_MEASURED` |
+| `chemistry.(shot_id, fraction_id)` | `val_data_001_fractions.csv.(shot_id, fraction_id)` | many-to-one, both `NOT NULL`; partition must agree |
+| `files.(evidence_partition_id, campaign_instance_id)` | `val_data_001_evidence_partitions.csv.(evidence_partition_id, campaign_instance_id)` | many-to-one, both `NOT NULL`; partition route must agree with campaign |
+| `compatibility_packages.(evidence_partition_id, campaign_instance_id, route_id)` | `val_data_001_evidence_partitions.csv.(evidence_partition_id, campaign_instance_id, route_id)` | many-to-one, all `NOT NULL`; one partition per package |
+| `compatibility_packages.assembly_processing_id` | `val_data_001_processing_operations.csv.processing_id` | many-to-one, `NOT NULL`; parent scope is `NORMALIZED_FILE_ASSEMBLY` or `COMPATIBILITY_EXPORT` as applicable |
+| `export_grids.compatibility_package_id`, `export_source_rows.compatibility_package_id` | `val_data_001_compatibility_packages.csv.compatibility_package_id` | many-to-one, `NOT NULL` |
+| `export_source_rows.value_processing_id`, `export_source_rows.export_processing_id` | `val_data_001_processing_operations.csv.processing_id` | value ID nullable only for raw source; export ID `NOT NULL` with scope `COMPATIBILITY_EXPORT` |
+| `resources.(payload_schema_id, resource_type)` | `val_data_001_resource_type_schemas.csv.(payload_schema_id, resource_type)` | many-to-one, both `NOT NULL` |
 
 ### Resource-reference matrix
 
@@ -381,8 +508,8 @@ reference below resolves to one complete parent key. The required parent
 |---|---|
 | `evidence_routes.prospective_freeze_resource_id` | `FREEZE_IDENTITY` |
 | `evidence_routes.human_owner_disposition_resource_id` | `HUMAN_DISPOSITION` |
-| `evidence_routes.rights_policy_resource_id`, `evidence_partitions.rights_resource_id`, `resources.rights_resource_id`, `files.rights_resource_id` | `RIGHTS` |
-| `evidence_routes.access_policy_resource_id`, `evidence_partitions.access_policy_resource_id` | `ACCESS_POLICY` |
+| `evidence_routes.rights_policy_resource_id`, `evidence_partitions.rights_resource_id`, `compatibility_packages.rights_resource_id`, `resources.rights_resource_id`, `files.rights_resource_id` | `RIGHTS` |
+| `evidence_routes.access_policy_resource_id`, `evidence_partitions.access_policy_resource_id`, `compatibility_packages.access_policy_resource_id` | `ACCESS_POLICY` |
 | `evidence_partitions.custodian_resource_id` | `CUSTODIAN` |
 | `campaigns.contributor_resource_id` | `CONTRIBUTOR` |
 | `campaigns.external_repository_resource_id` | `EXTERNAL_REPOSITORY` |
@@ -417,12 +544,15 @@ reference below resolves to one complete parent key. The required parent
 | `files.creator_software_resource_id` | `SOFTWARE` |
 | `processing_operations.operation_resource_id` | `OPERATION` |
 | `chemistry.analytical_method_resource_id` | `ANALYTICAL_METHOD` |
+| `export_grids.grid_freeze_resource_id` | `FREEZE_IDENTITY` |
 
 `resources.source_file_id` references `files.source_file_id`; it is `NOT NULL`
 when `resources.resource_provenance_mode=SOURCE_FILE_BOUND` and null only when
-that field is `INLINE_DECLARATION`. `resources.rights_resource_id` references a globally unique resource
-of type `RIGHTS`; it may be null only when the resource itself is documented
-as `PUBLIC_DOMAIN` in `resources.definition`.
+that field is `INLINE_DECLARATION`, except that terminal `RIGHTS` resources
+always carry provenance in their canonical payload and have null
+`source_file_id`. `resources.rights_resource_id` references a globally unique
+terminal resource of type `RIGHTS`; only a `RIGHTS` resource itself may have a
+null rights reference.
 
 ### Controlled enumerations
 
@@ -448,6 +578,10 @@ as `PUBLIC_DOMAIN` in `resources.definition`.
 | `resource_provenance_mode` | `INLINE_DECLARATION`; `SOURCE_FILE_BOUND` |
 | `campaign_mapping_status` | `LOCKED_PUCKWORKS_CAMPAIGN`; `PUCKWORKS_MACHINE_MODE_CAMPAIGN_GAP_LOCAL_EXTENSION`; `FUTURE_PUCKWORKS_CAMPAIGN_PENDING` |
 | `edge_role` | `INPUT`; `OUTPUT` |
+| `operation_scope` | `ROW_VALUE`; `NORMALIZED_FILE_ASSEMBLY`; `COMPATIBILITY_EXPORT` |
+| `fraction_state` | `PRESENT`; `NOT_APPLICABLE_NO_FRACTIONATED_CHEMISTRY` |
+| `package_access_status` | `OPEN_AUTHORIZED`; `CALIBRATION_ACCESS`; `SEALED_UNACCESSED`; `AUTHORIZED_OPENED`; `PUBLIC_METADATA_ONLY` |
+| `export_status` | `NOT_GENERATED`; `GENERATED_VERIFIED`; `PROHIBITED_SEALED`; `NOT_APPLICABLE` |
 
 ### Route-conditional partition representation
 
@@ -497,10 +631,10 @@ for `upstream_pressure_availability=NOT_MEASURED`. `SENSOR_FAILURE` retains a
 referenced signal sample whose `missing_value_state=SENSOR_FAILURE`.
 
 A control reference with `raw_or_processed=PROCESSED_SYNCHRONIZED` points to a
-signal row with the same state and mandatory `processing_id`.
+signal row with the same state and mandatory `value_processing_id`.
 `control_deviation_pa` identifies the exact basket sample above and is derived
 from that sample and `commanded_pressure_value`; any populated deviation
-therefore requires the control row's `processing_id` to identify the deriving
+therefore requires the control row's `value_processing_id` to identify the deriving
 operation.
 If duplicated presentation values are exported later, they must be byte- and
 value-derived from that signal row; conflicts resolve in favor of the signal
@@ -532,6 +666,16 @@ table and invalidate the export.
    normalized source during verification. Exported/local disagreement,
    missing input edges, or ambiguous producing operations invalidate the
    export.
+8. `ROW_VALUE` operations may produce normalized value files but never final
+   package assembly. `NORMALIZED_FILE_ASSEMBLY` consumes authoritative row
+   files and produces complete normalized submission files.
+   `COMPATIBILITY_EXPORT` consumes verified normalized files and produces only
+   the partition-specific Puckworks presentation. Scope mixing invalidates the
+   graph.
+9. No file-to-file parent column supplies provenance. Reachability, complete
+   input multiplicity, the unique producer, software identity, parameters,
+   and output identity are reconstructed exclusively from operation rows and
+   input/output edges.
 
 ### Cross-table relational invariants
 
@@ -564,6 +708,22 @@ table and invalidate the export.
    non-null `puckworks_campaign_id`. Both gap/pending statuses require it to be
    null and prohibit compatibility export. The mapping status and selected
    route are frozen before commissioning.
+10. A signal or deformation row's shot apparatus, registry apparatus, sensor,
+    observable or node, native unit, and clock are identical. Calibration
+    applicability and acquisition-time validity are enforced from that same
+    registry row.
+11. Fractions and chemistry inherit the shot's campaign, route, and evidence
+    partition. Chemistry cannot exist without its exact fraction parent.
+12. A compatibility package, its grid, every exported source row, all input
+    files, and every exported shot belong to one campaign and one evidence
+    partition. Route-B calibration and sealed-scoring partitions never share
+    a package or processing operation.
+13. Resource payloads validate against their type-specific schema. Every
+    non-rights resource and file terminates in exactly one direct `RIGHTS`
+    resource, and a rights resource has no rights or source-file parent.
+14. Every synchronized export row has one frozen grid position and complete
+    source-key records. Every achieved-mass value has one exact terminal
+    delivered-mass source key selected by the frozen termination rule.
 
 ## Timebase, timing, calibration, and latency
 

--- a/docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md
+++ b/docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md
@@ -103,23 +103,26 @@ pilot decisions.
 
 ## Parameter and evidence-role ledger
 
-Every final role must be frozen before commissioning. `Unused outputs` below
-must remain unused for fitting if they will support an independent comparison.
+The frozen protocol classification is historical fact and is not a proposed
+future evidence role. Every prospective role must be frozen before
+commissioning.
 
-| Item; definition and units | Current status and preferred independent source | Campaign/gap and future role | Permitted calibration evidence; unused comparison outputs; holdout restriction | Circularity consequence and unresolved disposition |
-|---|---|---|---|---|
-| `k0`, reference intrinsic permeability (m2) | uncertain model input; independent constant-head/pressure-flow characterization bound to the compared coffee, grinder, packing, and shot | EXP-003; measured input, calibration quantity, or withheld comparison input | Separate characterization may calibrate it; comparison-shot flow/pressure must remain unused if independently scored; sealed records require separate access authority | Fitting from the scored pressure-flow response destroys independence for that response; `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING` |
-| `pc`, compaction pressure scale (Pa) | uncertain model input; independent mechanical pressure/deformation characterization | EXP-004; calibration quantity or withheld compaction parameter | Calibration subset may fit it; withheld pressure/deformation outputs remain untouched; holdout identities sealed prospectively | Fitting and scoring the same deformation curve is circular; `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING` |
-| `phi0`, stress-free/reference porosity (1) | uncertain model input; independent geometry, dose, density, and packing characterization bound to each compared shot | EXP-003; measured input or calibration quantity | Characterization may supply it; compared-shot deformation/flow outputs remain unused for fitting; sealed partitions require separate authority | Inferring it from the scored hydraulic response removes independence; `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING` |
-| `Cu`, machine/upstream compliance (m3/Pa) | uncertain machine input; independent volume-pressure or transient hydraulic characterization | machine-mode campaign gap | Separate machine characterization or declared calibration subset; withheld upstream/basket transient outputs remain unused; no holdout access here | Inferring `Cu` from the same scored transient confounds machine and puck response; `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING` |
-| `Ru`, upstream hydraulic resistance (Pa s/m3) | uncertain machine input; independent line-resistance characterization | machine-mode campaign gap | Separate machine characterization or calibration subset; withheld pressure-drop/flow outputs remain unused; telemetry role must be declared | Telemetry-derived `Ru` cannot independently validate that same pressure-drop response; `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING` |
-| `Qfree`, free-flow supply parameter (m3/s) | uncertain machine input; independent no-puck free-flow characterization | machine-mode campaign gap | Characterization may prescribe it; scored machine/puck flow remains unused; any sealed comparison is separately controlled | Derivation from scored coupled flow creates circular machine-boundary evidence; `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING` |
-| `pshut`, shutoff-pressure supply parameter (Pa gauge) | uncertain machine input; independent safe shutoff/supply-curve characterization | machine-mode campaign gap | Characterization may prescribe it; scored upstream/basket pressures remain unused; sealed access requires separate authority | Derivation from the scored coupled pressure response destroys independence; `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING` |
-| universal/finite-porosity model-form switch (categorical) | existing model-form switch; no fitting source | EXP-004 plus EXP-001 telemetry; future withheld model-form comparison | Calibration/model selection must use only a declared subset; all discriminator outputs in a sealed subset remain untouched | Choosing the branch on scored outputs invalidates independent discrimination; `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING` |
-| viscosity, dynamic viscosity (Pa s) | measured/source-derived input; traceable temperature-dependent fluid property | EXP-001 temperature metadata | Independently prescribed or calculated before comparison; scored flow is not a property-fitting source; sealed output access prohibited | Back-calculating viscosity from scored flow makes hydraulic comparison circular; `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING` |
-| density, fluid density (kg/m3) | measured/source-derived input; traceable gravimetric/volumetric or temperature-dependent property | EXP-001 | Independently prescribed for mass/volume conversion; scored mass and flow remain unused for fitting; provenance travels with partition | Estimating density to reconcile scored mass and volume flow compromises that comparison; `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING` |
-| wetting/first-drip inputs, including dry-bed and inlet/timing quantities (declared native units) | uncertain/measured inputs; independent preparation metadata and physical marker characterization | EXP-002 | Pilot/characterization may define detection and inputs; withheld first-drip timing remains unused; ordinary replicates are not holdouts | Tuning wetting inputs to scored first drip prevents an independent timing claim; `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING` |
-| downstream extraction/dissolution quantities used in a comparison (quantity-specific SI units) | existing inputs/outputs; independent chemistry, dose, and material characterization | EXP-001 and EXP-003 | Only explicitly declared calibration quantities may be fitted; cup chemistry and extraction outputs intended for comparison remain unused and separately partitioned | Fitting against the same chemistry/extraction response precludes independent scoring; `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING` |
+| Item; definition and units | `CURRENT_VAL_CASE_001_CLASSIFICATION` | Preferred source and campaign/gap | `PROSPECTIVE_VAL_DATA_001_ROLE`; calibration/comparison restriction |
+|---|---|---|---|
+| `k0`, reference intrinsic permeability (m2) | `CALIBRATED_PREVIOUSLY` | independent constant-head/pressure-flow characterization bound to the compared material and shot; EXP-003 | `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING`; if recalibrated, the same pressure/flow observations cannot support an independent fitted-response comparison |
+| `pc`, compaction pressure scale (Pa) | `SOURCE_DERIVED` | independent mechanical pressure/deformation characterization; EXP-004 | `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING`; a fitted deformation curve cannot independently validate `pc` |
+| `phi0`, stress-free/reference porosity (1) | `FIXED_PREDECESSOR_VALUE` | independently measured geometry, dose, density, and packing bound to the shot; EXP-003 | `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING`; hydraulic inference from scored outputs destroys independence |
+| `Cu`, upstream compliance (m3/Pa) | `UNCERTAIN_MODEL_INPUT` | independent volume-pressure or transient characterization; machine-mode campaign gap | `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING`; telemetry must be assigned to characterization, calibration, or untouched comparison before access |
+| `Ru`, upstream resistance (Pa s/m3) | `UNCERTAIN_MODEL_INPUT` | independent line-resistance characterization; machine-mode campaign gap | `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING`; telemetry-derived `Ru` cannot validate the same pressure-drop response |
+| `Qfree`, free-flow supply parameter (m3/s) | `UNCERTAIN_MODEL_INPUT` | independent no-puck free-flow characterization; machine-mode campaign gap | `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING`; coupled-shot scored flow cannot also determine `Qfree` |
+| `pshut`, shutoff-pressure supply parameter (Pa gauge) | `UNCERTAIN_MODEL_INPUT` | independent safe supply-curve characterization; machine-mode campaign gap | `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING`; scored coupled pressure cannot also determine `pshut` |
+| mechanics branch, universal/finite-porosity switch (categorical) | `MODEL_FORM_SWITCH` | EXP-004 deformation plus EXP-001 telemetry | `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING`; model selection and untouched model-form comparison must use route-permitted separate evidence |
+| viscosity, dynamic viscosity (Pa s) | `SOURCE_MEASURED`; `NOT_VARIED` | traceable temperature-dependent fluid property; EXP-001 metadata | independently prescribed input; scored flow must not be used to back-calculate it |
+| density, fluid density (kg/m3) | `SOURCE_MEASURED`; `NOT_VARIED` | traceable gravimetric/volumetric or temperature-dependent property; EXP-001 | independently prescribed conversion input; scored mass/flow must not tune it |
+| wetting permeability (m2) | `CALIBRATED_PREVIOUSLY`; `NOT_VARIED` | independently characterized dry-bed/wetting input; EXP-002 and EXP-003 | `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING`; first-drip comparison observations must remain unused if the response is claimed independent |
+| extraction constants (quantity-specific SI units) | `FIXED_PREDECESSOR_VALUE`; `NOT_VARIED` | independent chemistry/material sources; EXP-001 and EXP-003 | `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING`; scored chemistry/extraction cannot both fit and validate the same constants |
+| additional future wetting/timing inputs (field-specific units) | not part of the frozen varied-parameter inventory; listed separately | preparation metadata and physical marker characterization; EXP-002 | `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING`; pilot evidence is non-validation by default |
+| additional future chemistry/dissolution quantities (field-specific units) | not part of the frozen varied-parameter inventory; listed separately | independent chemistry, dose, and material characterization; EXP-001 and EXP-003 | `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING`; comparison outputs intended for scoring remain unused for fitting |
 
 When `k0`, `phi0`, PSD, or packing are supplied through EXP-003-style
 characterization, their identifiers and provenance must bind to the exact
@@ -170,33 +173,132 @@ This plan is a read-only extension of the templates under
 unchanged. A future submission must supply those templates plus the following
 normalized VAL-DATA-001 extension files.
 
-Common identifiers are non-empty strings. Primary keys are unique; foreign
-keys must resolve within the same checksum-bound submission. Missing values
-must be empty only when `missing_value_state` is one of `NOT_MEASURED`,
-`NOT_APPLICABLE`, `BELOW_DETECTION`, `SENSOR_FAILURE`, or `MISSING_UNKNOWN`;
-numeric zero is never a missing-value code.
+Common identifiers are non-empty strings. Primary keys are unique. Each
+foreign key resolves through the matrix below; there are no implied parents.
+Numeric zero is never a missing-value code.
 
-| File/table | Primary key and foreign keys | Required fields and canonical units |
+### Exact normalized tables
+
+| File/table | Primary key | Exact required fields |
 |---|---|---|
-| `val_data_001_campaign.csv` | PK `campaign_id`; FK `puckworks_campaign_id` to the locked campaign identity | `campaign_id`, `puckworks_campaign_id`, `site_id`, `apparatus_id`, `evidence_partition_id`, `analysis_role`, `rights_id`, `schema_version`; analysis role is one of `PILOT_NON_VALIDATION`, `CHARACTERIZATION`, `CALIBRATION`, `COMPARISON`, `SEALED_HOLDOUT`, or `TRANSFER` |
-| `val_data_001_conditions.csv` | PK `condition_id`; FK `campaign_id`, `apparatus_id` | `control_mode`, `prescribed_node`, `prescribed_pressure_pa_gauge`, `command_program_id`, `initial_hydraulic_state_id`, `ambient_reference_pa`, `zeroing_basis`, `ramp_definition`, `plateau_definition`, `termination_rule`, `control_tolerance_pa`, `missing_value_state` |
-| `val_data_001_shots.csv` | PK `shot_id`; FK `campaign_id`, `condition_id`, `apparatus_id`, `replicate_id`, `block_id`, `evidence_partition_id` | coffee/grinder/basket/dose/preparation/temperature identifiers, randomized order, `raw_or_processed`, `inclusion_status`, `exclusion_reason`, `t0_event_code`, `t0_uncertainty_s`; this extends locked `shot_metadata.csv` rather than changing it |
-| `val_data_001_signals.csv` | composite PK (`shot_id`, `signal_id`, `sample_index`); FK `shot_id`, `sensor_id`, `clock_id`, `calibration_id`, `source_file_id`, optional `parent_processing_id` | `native_timestamp`, `elapsed_time_s`, `native_value`, `native_unit`, `canonical_value`, `canonical_unit`, `physical_node`, `raw_or_processed`, `quality_flags`, `missing_value_state`, `clock_offset_s`, `clock_drift_s_per_s`, `sensor_latency_s`, `resampling_interval_s` |
-| `val_data_001_controls.csv` | composite PK (`shot_id`, `control_sample_index`); FK `shot_id`, `command_program_id`, `clock_id`, `source_file_id` | `native_timestamp`, `elapsed_time_s`, commanded/setpoint value and unit, `prescribed_node`, achieved basket-top pressure in Pa gauge, measured upstream pressure in Pa gauge, ambient reference in Pa, `control_deviation_pa`, `control_status`, ramp/plateau/termination state |
-| `val_data_001_flow_conversion.csv` | PK `conversion_id`; FK `shot_id`, `density_source_id`, optional `calibration_id` | native mass flow in g/s, native volume flow in mL/s when measured, canonical mass flow in kg/s, canonical volume flow in m3/s, density in kg/m3, temperature basis, conversion formula, density provenance, uncertainty record ID |
-| `val_data_001_deformation.csv` | composite PK (`shot_id`, `location_id`, `sample_index`); FK `shot_id`, `sensor_id`, `calibration_id`, `reference_state_id`, `source_file_id` | native/canonical displacement and units, compression sign, `spatial_basis`, axial/radial coordinates, reference state, fixture-compliance correction ID, coffee-bed-only value, quality/missing flags, timing fields |
-| `val_data_001_calibrations.csv` | PK `calibration_id`; FK `apparatus_id`, `sensor_id`, `source_file_id` | observable, native/canonical units, method, reference identity, timestamp, offset, scale, range, resolution, bandwidth, latency, drift, uncertainty-record ID, validity interval; extends locked `calibration.csv` |
-| `val_data_001_files.csv` | PK `source_file_id`; optional FK `parent_source_file_id`, `processing_id` | relative filename, role, `raw_or_processed`, SHA-256, byte count, media type, license/rights ID, creator software identity, transformation identity; extends locked `file_manifest.csv` |
-| `val_data_001_processing_lineage.csv` | PK `processing_id`; FKs to input `source_file_id` values and output `source_file_id` | software commit/tree, command or deterministic operation ID, parameters, input/output hashes, synchronization method, resampling method, operator role, timestamp |
+| `val_data_001_evidence_routes.csv` | `route_id` | `route_id`, `selected_route`, `calibration_evidence_class`, `scoring_evidence_class`, `prospective_freeze_resource_id`, `human_owner_disposition_resource_id`, `rights_policy_resource_id`, `access_policy_resource_id` |
+| `val_data_001_campaigns.csv` | `campaign_id` | `campaign_id`, `puckworks_campaign_id`, `site_id`, `apparatus_id`, `route_id`, `schema_version` |
+| `val_data_001_evidence_partitions.csv` | `evidence_partition_id` | `evidence_partition_id`, `campaign_id`, `route_id`, `analysis_role`, `evidence_class`, `sealed_status`, `partition_manifest_sha256`, `seal_timestamp_utc`, `custodian_resource_id`, `access_policy_resource_id`, `rights_resource_id` |
+| `val_data_001_replicates.csv` | `replicate_id` | `replicate_id`, `campaign_id`, `condition_id`, `block_id`, `replicate_sequence`, `randomization_sequence`, `evidence_partition_id` |
+| `val_data_001_blocks.csv` | `block_id` | `block_id`, `campaign_id`, `block_type`, `block_label`, `session_start_utc`, `coffee_lot_resource_id`, `grinder_state_resource_id`, `operator_role_resource_id`, `apparatus_state_resource_id`, `calibration_set_id` |
+| `val_data_001_resources.csv` | (`resource_type`, `resource_id`) | `resource_type`, `resource_id`, `definition`, `source_file_id`, `rights_resource_id` |
+| `val_data_001_conditions.csv` | `condition_id` | `condition_id`, `campaign_id`, `apparatus_id`, `control_mode`, `prescribed_node`, `prescribed_pressure_pa_gauge`, `command_program_resource_id`, `initial_hydraulic_state_resource_id`, `ambient_reference_pa`, `zeroing_basis`, `ramp_definition`, `plateau_definition`, `termination_rule`, `control_tolerance_pa`, `missing_value_state` |
+| `val_data_001_shots.csv` | `shot_id` | `shot_id`, `campaign_id`, `condition_id`, `apparatus_id`, `replicate_id`, `block_id`, `evidence_partition_id`, `coffee_lot_resource_id`, `grinder_resource_id`, `basket_resource_id`, `dose_g`, `dry_bed_depth_mm`, `preparation_protocol_resource_id`, `brew_temperature_c`, `raw_or_processed`, `inclusion_status`, `exclusion_reason`, `t0_event_code`, `t0_uncertainty_s` |
+| `val_data_001_signals.csv` | (`shot_id`, `signal_id`, `sample_index`) | `shot_id`, `signal_id`, `sample_index`, `sensor_resource_id`, `clock_resource_id`, `calibration_id`, `source_file_id`, `processing_id`, `native_timestamp`, `elapsed_time_s`, `native_value`, `native_unit`, `canonical_value`, `canonical_unit`, `physical_node`, `raw_or_processed`, `quality_flags`, `missing_value_state`, `clock_offset_s`, `clock_drift_s_per_s`, `sensor_latency_s`, `resampling_interval_s` |
+| `val_data_001_controls.csv` | (`shot_id`, `control_sample_index`) | `shot_id`, `control_sample_index`, `command_program_resource_id`, `clock_resource_id`, `source_file_id`, `processing_id`, `native_timestamp`, `elapsed_time_s`, `commanded_pressure_value`, `commanded_pressure_unit`, `prescribed_node`, `basket_pressure_signal_id`, `upstream_pressure_signal_id`, `control_deviation_pa`, `control_status`, `control_phase` |
+| `val_data_001_flow_conversions.csv` | `conversion_id` | `conversion_id`, `shot_id`, `density_source_resource_id`, `calibration_id`, `source_file_id`, `native_mass_flow_g_s`, `native_volume_flow_ml_s`, `canonical_mass_flow_kg_s`, `canonical_volume_flow_m3_s`, `density_kg_m3`, `density_temperature_c`, `conversion_formula`, `processing_id` |
+| `val_data_001_deformation.csv` | (`shot_id`, `location_id`, `sample_index`) | `shot_id`, `location_id`, `sample_index`, `sensor_resource_id`, `calibration_id`, `reference_state_resource_id`, `fixture_compliance_resource_id`, `source_file_id`, `processing_id`, `native_timestamp`, `elapsed_time_s`, `native_displacement_value`, `native_displacement_unit`, `canonical_displacement_m`, `compression_sign`, `spatial_basis`, `axial_coordinate_m`, `radial_coordinate_m`, `coffee_bed_displacement_m`, `quality_flags`, `missing_value_state` |
+| `val_data_001_calibrations.csv` | `calibration_id` | `calibration_id`, `calibration_set_id`, `apparatus_id`, `sensor_resource_id`, `source_file_id`, `observable_code`, `native_unit`, `canonical_unit`, `calibration_method`, `reference_resource_id`, `calibration_timestamp_utc`, `offset`, `scale`, `range_min`, `range_max`, `resolution`, `bandwidth_hz`, `latency_s`, `drift_per_s`, `uncertainty_resource_id`, `valid_from_utc`, `valid_to_utc` |
+| `val_data_001_files.csv` | `source_file_id` | `source_file_id`, `parent_source_file_id`, `processing_id`, `relative_filename`, `file_role`, `raw_or_processed`, `sha256`, `byte_count`, `media_type`, `rights_resource_id`, `creator_software_resource_id` |
+| `val_data_001_processing_lineage.csv` | `processing_id` | `processing_id`, `input_source_file_id`, `output_source_file_id`, `software_commit`, `software_tree`, `operation_resource_id`, `parameter_record`, `synchronization_method`, `resampling_method`, `operator_role_resource_id`, `processing_timestamp_utc` |
 
-The signal registry must include `P_MACHINE_UPSTREAM_RU_PA_GAUGE`,
-`P_BASKET_BED_TOP_PA_GAUGE`, commanded pressure as a separate control signal,
-`OUTLET_MASS_FLOW_G_S`, `OUTLET_VOLUME_FLOW_ML_S`, `DELIVERED_MASS_G`, and
-location-specific `DEFORMATION_MM` or `BED_HEIGHT_MM`. It must preserve native
-bar versus canonical Pa, native g/s or mL/s versus canonical SI, and density
-and conversion provenance. A processed value never replaces its raw parent.
-Evidence partition, analysis role, calibration links, quality flags, inclusion
-status, exclusion rationale, checksums, and processing lineage are mandatory.
+The locked Puckworks bindings are exact: `campaigns.puckworks_campaign_id`
+references `docs/data_requests/experimental_campaigns.yml` campaign key
+`$.campaigns[*].campaign_id`; `campaigns.site_id` references
+`docs/data_requests/templates/campaign_metadata.yml` key `$.site_id`; and
+`campaigns.apparatus_id`, `conditions.apparatus_id`, and
+`calibrations.apparatus_id` reference
+`docs/data_requests/templates/apparatus.yml` key `$.apparatus_id`, all at the
+locked commit and tree above. The local `campaign_id`, `shot_id`, and
+`replicate_id` values also populate the same-named columns in locked
+`shot_metadata.csv`; this is an equality/export binding, not an additional
+foreign-key parent.
+
+### Foreign-key resolution matrix
+
+Cardinality is child-to-parent. `NOT NULL` means every child row requires
+exactly one parent; `NULLABLE` states the sole permitted null condition.
+
+| Child field | Exact parent | Cardinality/null rule |
+|---|---|---|
+| `campaigns.puckworks_campaign_id` | locked `experimental_campaigns.yml` `$.campaigns[*].id` | many-to-one, `NOT NULL` |
+| `campaigns.site_id` | locked `campaign_metadata.yml` `$.site_id` | many-to-one, `NOT NULL` |
+| `campaigns.apparatus_id`, `conditions.apparatus_id`, `calibrations.apparatus_id` | locked `apparatus.yml` `$.apparatus_id` | many-to-one, `NOT NULL` |
+| `campaigns.route_id`, `evidence_partitions.route_id` | `val_data_001_evidence_routes.csv.route_id` | many-to-one, `NOT NULL` |
+| `evidence_partitions.campaign_id`, `replicates.campaign_id`, `blocks.campaign_id`, `conditions.campaign_id`, `shots.campaign_id` | `val_data_001_campaigns.csv.campaign_id` | many-to-one, `NOT NULL` |
+| `replicates.condition_id` | `val_data_001_conditions.csv.condition_id` | many-to-one, `NOT NULL` |
+| `replicates.block_id`, `shots.block_id` | `val_data_001_blocks.csv.block_id` | many-to-one, `NOT NULL` |
+| `replicates.evidence_partition_id`, `shots.evidence_partition_id` | `val_data_001_evidence_partitions.csv.evidence_partition_id` | many-to-one, `NOT NULL` |
+| `shots.condition_id` | `val_data_001_conditions.csv.condition_id` | many-to-one, `NOT NULL` |
+| `shots.replicate_id` | `val_data_001_replicates.csv.replicate_id` | one-to-one within a condition, `NOT NULL` |
+| `shots.apparatus_id` | locked `apparatus.yml` `$.apparatus_id` | many-to-one, `NOT NULL` |
+| `signals.shot_id`, `controls.shot_id`, `flow_conversions.shot_id`, `deformation.shot_id` | `val_data_001_shots.csv.shot_id` | many-to-one, `NOT NULL` |
+| every field ending `_resource_id` | `val_data_001_resources.csv.resource_id`, paired with the field-implied `resource_type` | many-to-one; `NOT NULL` except `resources.rights_resource_id`, which may be null only for a public-domain resource documented as `PUBLIC_DOMAIN` |
+| `signals.calibration_id`, `flow_conversions.calibration_id`, `deformation.calibration_id` | `val_data_001_calibrations.csv.calibration_id` | many-to-one; null only when `missing_value_state=NOT_APPLICABLE` and the signal definition proves no calibration applies |
+| `calibrations.calibration_set_id`, `blocks.calibration_set_id` | `val_data_001_resources.csv.resource_id` with `resource_type=CALIBRATION_SET` | many-to-one, `NOT NULL` |
+| every `source_file_id`, `input_source_file_id`, `output_source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one, `NOT NULL` |
+| `files.parent_source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one; null only for an instrument-native root file |
+| every `processing_id` | `val_data_001_processing_lineage.csv.processing_id` | many-to-one; null only when `raw_or_processed=RAW_NATIVE` |
+| `controls.basket_pressure_signal_id`, `controls.upstream_pressure_signal_id` | `val_data_001_signals.csv.signal_id` within the same `shot_id` | many-to-one; basket reference `NOT NULL`; upstream reference null only for prescribed mode when upstream pressure is `NOT_MEASURED` |
+
+### Controlled enumerations
+
+| Field | Permitted values |
+|---|---|
+| `selected_route` | `INDEPENDENT_COMPONENT_VALIDATION`; `CALIBRATION_THEN_HOLDOUT_OR_TRANSFER`; `SEPARATE_CHARACTERIZATION_THEN_INDEPENDENT_VALIDATION` |
+| `evidence_class` | `NOT_APPLICABLE`; `PILOT_NON_VALIDATION`; `CHARACTERIZATION`; `RECONSTRUCTION_OR_CALIBRATION`; `INDEPENDENT_COMPONENT_VALIDATION`; `HOLDOUT_OR_TRANSFER` |
+| `analysis_role` | `PILOT_NON_VALIDATION`; `CHARACTERIZATION`; `CALIBRATION`; `COMPARISON`; `SEALED_SCORING`; `TRANSFER` |
+| `control_mode` | `PRESCRIBED_BASKET_PRESSURE`; `MACHINE_COUPLED` |
+| `prescribed_node` | `P_BASKET_BED_TOP_PA_GAUGE`; `NOT_APPLICABLE_MACHINE_COUPLED` |
+| `raw_or_processed` | `RAW_NATIVE`; `PROCESSED_SYNCHRONIZED`; `DERIVED` |
+| `inclusion_status` | `INCLUDED`; `EXCLUDED_PREDECLARED_RULE`; `FAILED_RETAINED`; `PENDING_QC` |
+| `missing_value_state` | `PRESENT`; `NOT_MEASURED`; `NOT_APPLICABLE`; `BELOW_DETECTION`; `SENSOR_FAILURE`; `MISSING_UNKNOWN` |
+| `sealed_status` | `NOT_APPLICABLE`; `UNSEALED_CALIBRATION`; `SEALED_UNACCESSED`; `AUTHORIZED_OPENED`; `CLOSED_AFTER_SCORING` |
+| `physical_node`/signal code | `P_MACHINE_UPSTREAM_RU_PA_GAUGE`; `P_BASKET_BED_TOP_PA_GAUGE`; `OUTLET_MASS_FLOW_G_S`; `OUTLET_VOLUME_FLOW_ML_S`; `DELIVERED_MASS_G`; `DEFORMATION_UPPER_M`; `DEFORMATION_MID_M`; `DEFORMATION_LOWER_M`; `BED_HEIGHT_BULK_M`; `FIRST_DRIP_EVENT_S` |
+| `control_status` | `PENDING_FEASIBILITY`; `WITHIN_FROZEN_TOLERANCE`; `OUTSIDE_FROZEN_TOLERANCE`; `CONTROL_FAILURE` |
+| `control_phase` | `PRE_SHOT`; `RAMP`; `PLATEAU`; `TERMINATION`; `POST_SHOT` |
+| `block_type` | `SESSION`; `COFFEE_LOT`; `GRINDER_STATE`; `OPERATOR_STATE`; `APPARATUS_CALIBRATION_STATE` |
+| `location_id` | `UPPER_BED`; `MID_BED`; `LOWER_BED`; `BULK_EQUIVALENT` |
+| `resource_type` | `ACCESS_POLICY`; `APPARATUS_STATE`; `CALIBRATION_SET`; `COMMAND_PROGRAM`; `CUSTODIAN`; `DENSITY_SOURCE`; `FIXTURE_COMPLIANCE`; `FREEZE_IDENTITY`; `GRINDER`; `GRINDER_STATE`; `HUMAN_DISPOSITION`; `HYDRAULIC_INITIAL_STATE`; `OPERATION`; `OPERATOR_ROLE`; `PREPARATION_PROTOCOL`; `REFERENCE_STATE`; `REFERENCE_STANDARD`; `RIGHTS`; `SENSOR`; `SOFTWARE`; `UNCERTAINTY`; `COFFEE_LOT`; `BASKET`; `CLOCK` |
+
+### Route-conditional partition representation
+
+- `INDEPENDENT_COMPONENT_VALIDATION`: one or more partitions may represent
+  acquisition logistics, but every scored partition has
+  `analysis_role=COMPARISON`,
+  `evidence_class=INDEPENDENT_COMPONENT_VALIDATION`, and
+  `sealed_status=NOT_APPLICABLE`. No `CALIBRATION` or `SEALED_SCORING`
+  partition is required or permitted within that scored dataset.
+  Its route record uses `calibration_evidence_class=NOT_APPLICABLE` and
+  `scoring_evidence_class=INDEPENDENT_COMPONENT_VALIDATION`.
+- `CALIBRATION_THEN_HOLDOUT_OR_TRANSFER`: at least one partition has
+  `analysis_role=CALIBRATION`,
+  `evidence_class=RECONSTRUCTION_OR_CALIBRATION`, and
+  `sealed_status=UNSEALED_CALIBRATION`; at least one disjoint partition has
+  `analysis_role=SEALED_SCORING`, `evidence_class=HOLDOUT_OR_TRANSFER`, and
+  `sealed_status=SEALED_UNACCESSED` before fitting. Both partition manifests
+  and their route freeze identity are fixed before calibration access.
+  Its route record uses
+  `calibration_evidence_class=RECONSTRUCTION_OR_CALIBRATION` and
+  `scoring_evidence_class=HOLDOUT_OR_TRANSFER`.
+- `SEPARATE_CHARACTERIZATION_THEN_INDEPENDENT_VALIDATION`: two distinct
+  `campaign_id` values are required. The first has a `CHARACTERIZATION`
+  partition with `evidence_class=CHARACTERIZATION`; the later campaign has a
+  wholly untouched `COMPARISON` partition with
+  `evidence_class=INDEPENDENT_COMPONENT_VALIDATION`. The later campaign is not
+  a holdout subset of the first.
+  Its route record uses `calibration_evidence_class=CHARACTERIZATION` and
+  `scoring_evidence_class=INDEPENDENT_COMPONENT_VALIDATION`.
+
+Every replicate belongs to exactly one condition, block, and evidence
+partition. Blocks encode acquisition structure only; neither a block nor an
+ordinary replicate becomes holdout evidence unless Route B prospectively
+assigns its enclosing partition to `SEALED_SCORING`.
+
+Measured pressure samples have one source of truth:
+`val_data_001_signals.csv`. `val_data_001_controls.csv` contains command and
+state records plus `basket_pressure_signal_id` and
+`upstream_pressure_signal_id`; it contains no independently authoritative
+measured-pressure value. `control_deviation_pa` is derived from the referenced
+basket signal and commanded pressure and therefore requires `processing_id`.
+If duplicated presentation values are exported later, they must be byte- and
+value-derived from that signal row; conflicts resolve in favor of the signal
+table and invalidate the export.
 
 ## Timebase, timing, calibration, and latency
 
@@ -263,9 +365,23 @@ missingness/failure modes, and deformation-reference stability. They remain
 Final replicates are `DESIGN_CALCULATION_REQUIRED`. The later calculation must
 use pilot estimates of within-condition and between-block variance, the
 smallest predeclared discrimination contrast, desired interval width or power,
-multiple-condition structure, anticipated exclusions, and independent holdout
-allocation. It must document assumptions and sensitivity to them; this plan
-does not invent a replicate count or power value.
+multiple-condition structure, and anticipated exclusions. It must document
+assumptions and sensitivity to them; this plan does not invent a replicate
+count or power value. Partition and access rules depend on the selected route:
+
+- `INDEPENDENT_COMPONENT_VALIDATION`: calculate replication for the complete
+  independent comparison dataset. No within-dataset calibration/holdout split
+  is required. Freeze evidence identity, rights, protocol, and access policy
+  before outcome access; the entire scored dataset remains unused for fitting
+  and model selection.
+- `CALIBRATION_THEN_HOLDOUT_OR_TRANSFER`: calculate calibration and scoring
+  replication separately. Freeze partition membership and manifest hashes
+  before fitting; seal the scoring partition. Opening or scoring it requires
+  separate authority and leakage controls.
+- `SEPARATE_CHARACTERIZATION_THEN_INDEPENDENT_VALIDATION`: calculate the
+  characterization campaign and later independent campaign separately.
+  Characterization is non-validation evidence; the later campaign remains
+  wholly untouched and is not an ordinary holdout subset of the earlier one.
 
 Randomize condition order within feasible thermal/preparation blocks. Predefine
 blocks for day/session, coffee batch, grinder state, operator or automation
@@ -299,7 +415,7 @@ or documented preparation failure may exclude a run only under a preregistered
 rule. Preserve the run, raw files, flags, and rationale. Scientific disagreement
 is never an exclusion reason.
 
-## Preregistered analysis, fitting separation, and holdout
+## Route-conditional preregistration, partitioning, and access
 
 Before access to comparison outcomes, preregister time origin, filtering and
 resampling, feature definitions, uncertainty propagation, missingness,
@@ -307,12 +423,18 @@ exclusions, parameter/model-form metrics, thresholds, and interpretation.
 Separate prescribed quantities, independently measured inputs, calibration
 quantities, comparison outputs, contextual metadata, and excluded quantities.
 
-Allocate holdout units or blocks before fitting and seal their identities and
-files. Calibration and model selection must not use holdout observations.
-Holdout access and scoring require separate authority; they are not authorized
-here. Downstream decisions must distinguish inadequate measurement information,
-parameter confounding, model-form discrimination, and persistent structured
-residuals.
+For `INDEPENDENT_COMPONENT_VALIDATION`, preregister the complete comparison and
+freeze the complete dataset identity before outcome access; there is no
+required within-dataset holdout allocation. For
+`CALIBRATION_THEN_HOLDOUT_OR_TRANSFER`, preregister calibration and scoring
+roles, freeze and seal scoring units or blocks before fitting, and prohibit
+calibration/model selection from using them. For
+`SEPARATE_CHARACTERIZATION_THEN_INDEPENDENT_VALIDATION`, preregister the later
+campaign independently and keep it wholly inaccessible during characterization
+and model selection. Holdout access and scoring, when Route B is selected,
+require separate authority and are not authorized here. Downstream decisions
+must distinguish inadequate measurement information, parameter confounding,
+model-form discrimination, and persistent structured residuals.
 
 ## Rights, privacy, and deposit
 
@@ -337,7 +459,8 @@ and citation metadata. Rights must permit the intended independent comparison.
 - [ ] Apparatus and node feasibility: `APPARATUS_FEASIBILITY_REQUIRED`.
 - [ ] Sensors and calibration chain: `SENSOR_SELECTION_REQUIRED`.
 - [ ] Pilot protocol and evidence: `PILOT_REQUIRED`.
-- [ ] Replication and holdout calculation: `DESIGN_CALCULATION_REQUIRED`.
+- [ ] Route-appropriate replication and partition calculation:
+      `DESIGN_CALCULATION_REQUIRED`.
 - [ ] Randomization, blocks, exclusions, and preregistered analysis frozen.
 - [ ] Rights, privacy, custody, and deposit plan accepted.
 - [ ] Safety and operational review accepted by responsible humans.

--- a/docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md
+++ b/docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md
@@ -287,7 +287,7 @@ chemistry rows.
 sorted object keys, no insignificant whitespace, JSON `null` only where the
 type schema permits it, finite base-10 numbers, and no duplicate keys.
 Required payload members are: `CONTRIBUTOR{contact,role}`;
-`EXTERNAL_REPOSITORY{repository,doi}`; `RIGHTS{license,access_class,
+`EXTERNAL_REPOSITORY{external_repository,doi}`; `RIGHTS{license,access_class,
 redistribution_status}`;
 `SENSOR{display_text,manufacturer,model,serial_or_asset_id}`;
 `CLOCK{display_text,clock_id,clock_basis}`;
@@ -296,8 +296,14 @@ redistribution_status}`;
 `GRINDER{display_text,identity,definition,grinder_setting}`; machine, grinder
 model, burr, basket, and grinder-setting resources
 `{display_text,identity,definition}`; command, preparation, reference, density, and
-operation resources `{method,version,parameters}`; and all remaining
-enumerated types `{definition,status}`. Unresolved real-world values use the
+operation resources `{method,version,parameters}`;
+`DEVIATION_RECORD{display_text,definition,status}`;
+`OPERATOR_ROLE{display_text,definition,status}`;
+`ANALYTICAL_METHOD{display_text,definition,status}`; and all remaining
+enumerated types `{definition,status}`. `exclusions.csv.recorded_by` is
+exactly `OPERATOR_ROLE.display_text`, and
+`chemistry_measurements.csv.analytical_method` is exactly
+`ANALYTICAL_METHOD.display_text`. Unresolved real-world values use the
 applicable controlled unresolved disposition, not invented values.
 Every used `payload_schema_id` resolves to
 `val_data_001_resource_type_schemas.csv`; the schema row's `resource_type`
@@ -359,7 +365,7 @@ zero fraction and zero chemistry rows and prohibits fabricated empty rows.
 | Content mode | Files and observations | `export_processing_id` | `export_grid_id` |
 |---|---|---|---|
 | `FULL_COMPATIBILITY_EXPORT` | Complete partition-authorized compatibility files, including `shot_timeseries.csv` | required; scope exactly `COMPATIBILITY_EXPORT` | required; exactly one reciprocal grid |
-| `METADATA_CHECKSUM_ONLY` | Only rights/access metadata, seal identity, and checksum manifest; no observations or time-series sources | required; scope exactly `COMPATIBILITY_EXPORT` | null |
+| `METADATA_CHECKSUM_ONLY` | Only rights/access metadata, seal identity, and checksum manifest; no observations or time-series sources | required; scope exactly `SEALED_METADATA_ASSEMBLY` | null |
 | `NOT_GENERATED` | No compatibility files | null | null |
 | `NOT_APPLICABLE` | No compatibility files | null | null |
 
@@ -382,8 +388,8 @@ empty file set.
 #### Row-value and file-assembly lineage
 
 `operation_scope` is exactly one of `ROW_VALUE`,
-`NORMALIZED_FILE_ASSEMBLY`, or
-`COMPATIBILITY_EXPORT`. A row's `value_processing_id` references only a
+`NORMALIZED_FILE_ASSEMBLY`, `COMPATIBILITY_EXPORT`, or
+`SEALED_METADATA_ASSEMBLY`. A row's `value_processing_id` references only a
 `ROW_VALUE` operation and is null only for a directly reported raw native
 value. File assembly and compatibility export operations never masquerade as
 row-value transformations. `parent_source_file_id` is not part of the files
@@ -392,10 +398,12 @@ schema and is not authoritative. All actual dependencies use
 output producer, every producer has at least one input and one output, native
 files have no output producer, and the bipartite file-operation graph is
 acyclic. A generated compatibility package references exactly one
-`export_processing_id`, whose operation scope is `COMPATIBILITY_EXPORT`;
+`export_processing_id`: full mode requires `COMPATIBILITY_EXPORT`, while
+metadata-only mode requires `SEALED_METADATA_ASSEMBLY`;
 non-generated and not-applicable modes reference none.
-`NORMALIZED_FILE_ASSEMBLY` is never accepted for package export. Every export
-source row references the package's same export operation.
+`NORMALIZED_FILE_ASSEMBLY` is never accepted for package export. Full-export
+source rows reference the package's same `COMPATIBILITY_EXPORT` operation;
+sealed-envelope files reference only its `SEALED_METADATA_ASSEMBLY` operation.
 
 #### Exact synchronized-time-series and terminal-mass export
 
@@ -560,6 +568,88 @@ scale `1`, offset `-273.15`; and a value already in its target unit uses mode
 frozen in that row, with presentation scale `1` and offset `0`. No other conversion is admissible without a prospectively
 amended contract.
 
+#### Compatibility serialization closure
+
+This subsection is normative and supersedes less-specific serialization and
+manifest prose. Every resource export expression is checked against the
+closed member maps in `val_data_001_resource_type_schemas.csv`. In particular,
+`EXTERNAL_REPOSITORY.external_repository`, `DEVIATION_RECORD.display_text`,
+`OPERATOR_ROLE.display_text`, and `ANALYTICAL_METHOD.display_text` are required
+UTF-8 strings. No alias or undeclared generic member is accepted.
+
+The metadata-only files form a prospectively defined
+`SEALED_METADATA_ENVELOPE`, not a filled Puckworks submission. One
+`SEALED_METADATA_ASSEMBLY` operation (a fourth operation scope) emits them and
+may consume only the named package, partition, terminal-rights, access-policy,
+and seal records.
+
+| File / object key | Required members in canonical order | Optional | Source |
+|---|---|---|---|
+| `package_manifest.json` / `compatibility_package_id` | `schema_version`, `envelope_type`, `compatibility_package_id`, `campaign_instance_id`, `evidence_partition_id`, `package_content_mode`, `files` | none | package row; frozen `SEALED_METADATA_ENVELOPE`; sorted file descriptors |
+| `rights_access.json` / `compatibility_package_id` | `schema_version`, `compatibility_package_id`, `evidence_partition_id`, `access_policy_resource_id`, `rights_resource_id`, `package_access_status` | none | exact package and partition |
+| `seal_identity.json` / `evidence_partition_id` | `schema_version`, `compatibility_package_id`, `evidence_partition_id`, `sealed_status`, `partition_manifest_sha256`, `seal_timestamp_utc`, `custodian_resource_id` | none | exact package and partition |
+
+These are closed (`additionalProperties=false`) UTF-8 JSON schemas with LF
+termination, no BOM or insignificant whitespace, and members in displayed
+order. `files` has exactly two objects ordered by `filename`, for
+`rights_access.json` and `seal_identity.json`; each has members in order
+`filename`, `sha256`, `bytes`. Hashes are lowercase 64-hex and byte counts are
+unsigned decimals. Filenames are package-relative basenames; absolute, `.` or
+`..` paths, duplicates, and normalization collisions fail. Field provenance
+is the source above; file provenance is the unique assembly output edge.
+
+`package_manifest.json` never lists or hashes itself. Its externally computed
+hash is stored only in `compatibility_packages.package_manifest_sha256` and
+the normalized file registry. The other envelope files contain no self-hash.
+The envelope contains no observations, counts, exclusions, time grids, or
+presentation exports. The locked Puckworks `validate-submission` command
+applies only to `FULL_COMPATIBILITY_EXPORT`; an envelope is
+`SEALED_METADATA_ENVELOPE_SCHEMA_VALID_ONLY`, never a successful Puckworks
+submission. Observation access and later full export require separate
+authority.
+
+For a full export, `file_manifest.csv` lists every other emitted compatibility
+file exactly once and never itself. Its checksum remains in the normalized
+file registry and enclosing canonical package-manifest calculation. That
+calculation hashes an ordered descriptor containing `file_manifest.csv` and
+all files it lists, but never its own resulting hash. Duplicate filenames or
+conflicting file rows invalidate assembly.
+
+Serialization ordering is exact:
+
+| File | Order |
+|---|---|
+| `campaign_metadata.yml` | locked keys: `campaign_id`, `site_id`, `contributor`, `dataset_status`, `evidence_level_claimed`, `external_repository`, `doi`, `data_license`, `timezone`, `replicate_count`, `exclusions_recorded`, `deviations_from_protocol`, `declaration`; declaration keys: `no_private_or_unlicensed_third_party_data`, `submission_does_not_authorize_a_model_or_evidence_upgrade` |
+| `apparatus.yml` | locked keys: `apparatus_id`, `machine_make_model`, `grinder_make_model`, `burr_geometry`, `burr_wear_state`, `basket_geometry`, `signals`; signals ascending `signal_id`; signal keys: `observable`, `instrument`, `native_unit`, `native_sampling_rate`, `calibration`, `uncertainty`, `clock_source`, `synchronization_method`, `offset_drift_estimate`, `prescribed_or_measured` |
+| `shot_metadata.csv` | ascending `shot_id` |
+| `shot_timeseries.csv` | ascending `shot_id`, then numeric `elapsed_s` |
+| `calibration.csv` | ascending source `calibration_id` |
+| `exclusions.csv` | ascending `shot_id` |
+| `file_manifest.csv` | ascending `filename` |
+| `fraction_metadata.csv` | ascending `shot_id`, then `fraction_id` |
+| `chemistry_measurements.csv` | ascending `shot_id`, then `fraction_id`, then `species` |
+
+CSV headers remain the exact locked headers. Identifier sorts compare NFC
+strings by Unicode code point; elapsed time compares its finite decimal value.
+Duplicate keys, normalized collisions, numeric-time ties within a shot, and
+filename collisions fail export. Canonical YAML paths are dot-separated with
+no leading dot. The sole sequence form is
+`signals[signal_id=<canonical-id>].<member>`; indices and wildcards are
+prohibited, so every nested value has one stable path.
+
+The compatibility mapping is frozen: `RAW_NATIVE -> raw`,
+`PROCESSED_SYNCHRONIZED -> processed`, and `DERIVED -> processed`. It applies
+to every Puckworks `raw_or_processed` field. Missingness never changes row
+provenance, and `MISSING_DECLARED` is never emitted there.
+
+The deterministic audit fails unless every resource member exists with its
+declared type, every file has the closed schema and source contract, all YAML
+paths/sequences and CSV rows are uniquely ordered, every compatibility state
+is `raw` or `processed`, both manifests are nonrecursive, the envelope cannot
+be mistaken for a submission, and each full package is structurally eligible
+for the locked validator. It neither validates evidence nor authorizes access
+or commissioning.
+
 ### Deterministic Puckworks compatibility exports
 
 The normalized VAL-DATA-001 tables are authoritative. Locked Puckworks
@@ -628,10 +718,10 @@ the locked `shot_timeseries.csv` has no upstream-pressure column.
 | Remaining locked template | Exact field-level export rule |
 |---|---|
 | `calibration.csv` | scalar fields come from the calibration row; `instrument=SENSOR.display_text`; `notes` uses the exact canonical-JSON member set defined above |
-| `exclusions.csv` | `campaign_id=campaigns.puckworks_campaign_id`; `shot_id` and `replicate_id` from the shot; `exclusion_reason` from the shot; `recorded_by` from the applicable operator-role resource |
+| `exclusions.csv` | `campaign_id=campaigns.puckworks_campaign_id`; `shot_id` and `replicate_id` from the shot; `exclusion_reason` from the shot; `recorded_by=OPERATOR_ROLE.display_text` from the applicable operator-role resource |
 | `file_manifest.csv` | scalar fields come from the partition file row; `license=RIGHTS.license`; `notes` uses the exact canonical-JSON member set defined above |
 | `fraction_metadata.csv` | exact locked header; campaign mapping plus authoritative fraction-parent values, or package disposition `NOT_APPLICABLE_NO_FRACTIONATED_CHEMISTRY` |
-| `chemistry_measurements.csv` | when applicable, `campaign_id=campaigns.puckworks_campaign_id`; `shot_id`, `fraction_id`, `species`, `mass_mg`, `reference_basis`, `detection_limit_mg`, `recovery_pct`, and `measurement_status` from chemistry; `analytical_method` from its resource. When no chemistry is acquired, the file is declared `NOT_APPLICABLE` and is not fabricated |
+| `chemistry_measurements.csv` | when applicable, `campaign_id=campaigns.puckworks_campaign_id`; `shot_id`, `fraction_id`, `species`, `mass_mg`, `reference_basis`, `detection_limit_mg`, `recovery_pct`, and `measurement_status` from chemistry; `analytical_method=ANALYTICAL_METHOD.display_text`. When no chemistry is acquired, the file is declared `NOT_APPLICABLE` and is not fabricated |
 
 ### Primary and candidate keys
 
@@ -835,7 +925,7 @@ null rights reference.
 | `resource_provenance_mode` | `INLINE_DECLARATION`; `SOURCE_FILE_BOUND` |
 | `campaign_mapping_status` | `LOCKED_PUCKWORKS_CAMPAIGN`; `PUCKWORKS_MACHINE_MODE_CAMPAIGN_GAP_LOCAL_EXTENSION`; `FUTURE_PUCKWORKS_CAMPAIGN_PENDING` |
 | `edge_role` | `INPUT`; `OUTPUT` |
-| `operation_scope` | `ROW_VALUE`; `NORMALIZED_FILE_ASSEMBLY`; `COMPATIBILITY_EXPORT` |
+| `operation_scope` | `ROW_VALUE`; `NORMALIZED_FILE_ASSEMBLY`; `COMPATIBILITY_EXPORT`; `SEALED_METADATA_ASSEMBLY` |
 | `package_access_status` | `OPEN_AUTHORIZED`; `CALIBRATION_ACCESS`; `SEALED_UNACCESSED`; `AUTHORIZED_OPENED`; `CLOSED_AFTER_SCORING`; `PUBLIC_METADATA_ONLY` |
 | `export_status` | `NOT_GENERATED`; `GENERATED_VERIFIED`; `PROHIBITED_SEALED`; `NOT_APPLICABLE` |
 | `fraction_chemistry_status` | `PRESENT`; `NOT_APPLICABLE_NO_FRACTIONATED_CHEMISTRY` |

--- a/docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md
+++ b/docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md
@@ -183,56 +183,153 @@ Numeric zero is never a missing-value code.
 | File/table | Primary key | Exact required fields |
 |---|---|---|
 | `val_data_001_evidence_routes.csv` | `route_id` | `route_id`, `selected_route`, `calibration_evidence_class`, `scoring_evidence_class`, `prospective_freeze_resource_id`, `human_owner_disposition_resource_id`, `rights_policy_resource_id`, `access_policy_resource_id` |
-| `val_data_001_campaigns.csv` | `campaign_id` | `campaign_id`, `puckworks_campaign_id`, `site_id`, `apparatus_id`, `route_id`, `schema_version` |
-| `val_data_001_evidence_partitions.csv` | `evidence_partition_id` | `evidence_partition_id`, `campaign_id`, `route_id`, `analysis_role`, `evidence_class`, `sealed_status`, `partition_manifest_sha256`, `seal_timestamp_utc`, `custodian_resource_id`, `access_policy_resource_id`, `rights_resource_id` |
-| `val_data_001_replicates.csv` | `replicate_id` | `replicate_id`, `campaign_id`, `route_id`, `condition_id`, `block_id`, `replicate_sequence`, `randomization_sequence`, `evidence_partition_id` |
-| `val_data_001_blocks.csv` | `block_id` | `block_id`, `campaign_id`, `block_type`, `block_label`, `session_start_utc`, `coffee_lot_resource_id`, `grinder_state_resource_id`, `operator_role_resource_id`, `apparatus_state_resource_id`, `calibration_set_id` |
+| `val_data_001_sites.csv` | `site_id` | `site_id`, `site_privacy_status`, `rights_resource_id` |
+| `val_data_001_apparatus.csv` | `apparatus_id` | `apparatus_id`, `site_id`, `machine_make_model_resource_id`, `grinder_make_model_resource_id`, `burr_geometry_resource_id`, `burr_wear_state_resource_id`, `basket_geometry_resource_id` |
+| `val_data_001_apparatus_signals.csv` | (`apparatus_id`, `signal_id`) | `apparatus_id`, `signal_id`, `observable_code`, `sensor_resource_id`, `native_unit`, `native_sample_interval_s`, `calibration_applicability`, `uncertainty_resource_id`, `clock_resource_id`, `synchronization_method`, `offset_drift_resource_id`, `prescribed_or_measured` |
+| `val_data_001_campaigns.csv` | `campaign_instance_id` | `campaign_instance_id`, `puckworks_campaign_id`, `campaign_mapping_status`, `site_id`, `apparatus_id`, `route_id`, `contributor_resource_id`, `external_repository_resource_id`, `timezone`, `deviations_resource_id`, `schema_version` |
+| `val_data_001_evidence_partitions.csv` | `evidence_partition_id` | `evidence_partition_id`, `campaign_instance_id`, `route_id`, `analysis_role`, `evidence_class`, `sealed_status`, `partition_manifest_sha256`, `seal_timestamp_utc`, `custodian_resource_id`, `access_policy_resource_id`, `rights_resource_id` |
+| `val_data_001_replicates.csv` | `replicate_id` | `replicate_id`, `campaign_instance_id`, `route_id`, `condition_id`, `block_id`, `replicate_sequence`, `randomization_sequence`, `evidence_partition_id` |
+| `val_data_001_blocks.csv` | `block_id` | `block_id`, `campaign_instance_id`, `block_type`, `block_label`, `session_start_utc`, `coffee_lot_resource_id`, `grinder_state_resource_id`, `operator_role_resource_id`, `apparatus_state_resource_id`, `calibration_set_id` |
 | `val_data_001_resources.csv` | `resource_id` (globally unique) | `resource_id`, `resource_type`, `definition`, `resource_provenance_mode`, `source_file_id`, `rights_resource_id` |
-| `val_data_001_conditions.csv` | `condition_id` | `condition_id`, `campaign_id`, `apparatus_id`, `control_mode`, `prescribed_node`, `prescribed_pressure_pa_gauge`, `command_program_resource_id`, `initial_hydraulic_state_resource_id`, `ambient_reference_pa`, `zeroing_basis`, `ramp_definition`, `plateau_definition`, `termination_rule`, `control_tolerance_pa`, `missing_value_state` |
-| `val_data_001_shots.csv` | `shot_id` | `shot_id`, `campaign_id`, `route_id`, `condition_id`, `apparatus_id`, `replicate_id`, `block_id`, `evidence_partition_id`, `coffee_lot_resource_id`, `grinder_resource_id`, `basket_resource_id`, `dose_g`, `dry_bed_depth_mm`, `preparation_protocol_resource_id`, `brew_temperature_c`, `raw_or_processed`, `inclusion_status`, `exclusion_reason`, `t0_event_code`, `t0_uncertainty_s` |
+| `val_data_001_conditions.csv` | `condition_id` | `condition_id`, `campaign_instance_id`, `apparatus_id`, `control_mode`, `prescribed_node`, `prescribed_pressure_pa_gauge`, `command_program_resource_id`, `initial_hydraulic_state_resource_id`, `ambient_reference_pa`, `zeroing_basis`, `ramp_definition`, `plateau_definition`, `termination_rule`, `control_tolerance_pa`, `missing_value_state` |
+| `val_data_001_shots.csv` | `shot_id` | `shot_id`, `campaign_instance_id`, `route_id`, `condition_id`, `apparatus_id`, `replicate_id`, `block_id`, `evidence_partition_id`, `coffee_lot_resource_id`, `grinder_resource_id`, `basket_resource_id`, `dose_g`, `dry_bed_depth_mm`, `preparation_protocol_resource_id`, `target_beverage_g`, `brew_temperature_c`, `raw_or_processed`, `inclusion_status`, `exclusion_reason`, `t0_event_code`, `t0_uncertainty_s` |
 | `val_data_001_signals.csv` | (`shot_id`, `signal_id`, `sample_index`) | `shot_id`, `signal_id`, `sample_index`, `sensor_resource_id`, `clock_resource_id`, `calibration_id`, `source_file_id`, `processing_id`, `native_timestamp`, `elapsed_time_s`, `native_value`, `native_unit`, `canonical_value`, `canonical_unit`, `physical_node`, `raw_or_processed`, `quality_flags`, `missing_value_state`, `clock_offset_s`, `clock_drift_s_per_s`, `sensor_latency_s`, `resampling_interval_s` |
 | `val_data_001_controls.csv` | (`shot_id`, `control_sample_index`) | `shot_id`, `control_sample_index`, `command_program_resource_id`, `clock_resource_id`, `source_file_id`, `processing_id`, `raw_or_processed`, `native_timestamp`, `elapsed_time_s`, `commanded_pressure_value`, `commanded_pressure_unit`, `prescribed_node`, `basket_pressure_signal_id`, `basket_pressure_sample_index`, `upstream_pressure_signal_id`, `upstream_pressure_sample_index`, `upstream_pressure_availability`, `control_deviation_pa`, `control_status`, `control_phase` |
 | `val_data_001_flow_conversions.csv` | `conversion_id` | `conversion_id`, `shot_id`, `density_source_resource_id`, `calibration_id`, `calibration_applicability`, `source_file_id`, `native_mass_flow_g_s`, `native_volume_flow_ml_s`, `canonical_mass_flow_kg_s`, `canonical_volume_flow_m3_s`, `density_kg_m3`, `density_temperature_c`, `conversion_formula`, `processing_id` |
 | `val_data_001_deformation.csv` | (`shot_id`, `location_id`, `sample_index`) | `shot_id`, `location_id`, `sample_index`, `sensor_resource_id`, `calibration_id`, `reference_state_resource_id`, `fixture_compliance_resource_id`, `source_file_id`, `processing_id`, `raw_or_processed`, `native_timestamp`, `elapsed_time_s`, `native_displacement_value`, `native_displacement_unit`, `canonical_displacement_m`, `compression_sign`, `spatial_basis`, `axial_coordinate_m`, `radial_coordinate_m`, `coffee_bed_displacement_m`, `quality_flags`, `missing_value_state` |
+| `val_data_001_chemistry.csv` | (`shot_id`, `fraction_id`, `species`) | `shot_id`, `fraction_id`, `species`, `mass_mg`, `reference_basis`, `analytical_method_resource_id`, `detection_limit_mg`, `recovery_pct`, `measurement_status`, `source_file_id`, `processing_id` |
 | `val_data_001_calibrations.csv` | `calibration_id` | `calibration_id`, `calibration_set_id`, `apparatus_id`, `sensor_resource_id`, `source_file_id`, `observable_code`, `native_unit`, `canonical_unit`, `calibration_method`, `reference_resource_id`, `calibration_timestamp_utc`, `offset`, `scale`, `range_min`, `range_max`, `resolution`, `bandwidth_hz`, `latency_s`, `drift_per_s`, `uncertainty_resource_id`, `valid_from_utc`, `valid_to_utc` |
-| `val_data_001_files.csv` | `source_file_id` | `source_file_id`, `parent_source_file_id`, `processing_id`, `relative_filename`, `file_role`, `raw_or_processed`, `sha256`, `byte_count`, `media_type`, `rights_resource_id`, `creator_software_resource_id` |
-| `val_data_001_processing_lineage.csv` | `processing_id` | `processing_id`, `input_source_file_id`, `output_source_file_id`, `software_commit`, `software_tree`, `operation_resource_id`, `parameter_record`, `synchronization_method`, `resampling_method`, `operator_role_resource_id`, `processing_timestamp_utc` |
+| `val_data_001_files.csv` | `source_file_id` | `source_file_id`, `parent_source_file_id`, `relative_filename`, `file_role`, `raw_or_processed`, `sha256`, `byte_count`, `media_type`, `rights_resource_id`, `creator_software_resource_id`, `campaign_instance_id` |
+| `val_data_001_processing_operations.csv` | `processing_id` | `processing_id`, `software_commit`, `software_tree`, `operation_resource_id`, `parameter_record`, `synchronization_method`, `resampling_method`, `operator_role_resource_id`, `processing_timestamp_utc` |
+| `val_data_001_processing_file_edges.csv` | (`processing_id`, `edge_role`, `source_file_id`) | `processing_id`, `edge_role`, `source_file_id`, `edge_sequence`, `channel_or_output_role` |
 
 The locked Puckworks bindings distinguish immutable schemas from future data.
-`campaigns.puckworks_campaign_id` references actual catalog values in locked
+`campaign_instance_id` is the authoritative local identifier for one
+acquisition/submission instance. It is never exported as a Puckworks
+`campaign_id`. `puckworks_campaign_id` is the distinct `EXP-NNN` catalog
+identity and references actual values in locked
 `docs/data_requests/experimental_campaigns.yml` at
 `$.campaigns[*].campaign_id`. By contrast, locked
 `docs/data_requests/templates/campaign_metadata.yml` and
 `docs/data_requests/templates/apparatus.yml` are schemas/templates whose
 repository placeholder values are not parent data. `campaigns.site_id`
-references `$.site_id` in the future submitted `campaign_metadata.yml`
-instance conforming to that locked template. `campaigns.apparatus_id`,
-`conditions.apparatus_id`, `shots.apparatus_id`, and
-`calibrations.apparatus_id` reference `$.apparatus_id` in the future submitted
-`apparatus.yml` instance conforming to its locked template. The local
-`campaign_id`, `shot_id`, and `replicate_id` values also populate the
-same-named columns in a future submitted `shot_metadata.csv` instance; this is
-an equality/export binding, not another foreign-key parent.
+references the authoritative local site row and deterministically exports to
+`$.site_id` in the future submitted `campaign_metadata.yml` instance.
+Apparatus references resolve to the authoritative local apparatus row and
+deterministically export to `$.apparatus_id` in the future submitted
+`apparatus.yml` instance. Local `shot_id` and `replicate_id` values populate
+the same-named columns in a future submitted `shot_metadata.csv` instance; its
+`campaign_id` receives `puckworks_campaign_id`, not
+`campaign_instance_id`. These are deterministic export bindings, not
+additional foreign-key parents.
+
+`campaign_mapping_status` is frozen before commissioning. When it is
+`LOCKED_PUCKWORKS_CAMPAIGN`, `puckworks_campaign_id` is `NOT NULL` and resolves
+to the locked catalog. For
+`PUCKWORKS_MACHINE_MODE_CAMPAIGN_GAP_LOCAL_EXTENSION` or
+`FUTURE_PUCKWORKS_CAMPAIGN_PENDING`, `puckworks_campaign_id` is null. Thus the
+machine-mode gap remains representable under a local
+`campaign_instance_id` without inventing an EXP identifier. Such a local
+extension must not claim Puckworks submission compatibility until a valid
+catalog campaign is prospectively selected or created under separate
+authority.
+
+### Deterministic Puckworks compatibility exports
+
+The normalized VAL-DATA-001 tables are authoritative. Locked Puckworks
+templates define compatibility presentations only. Each exported file is an
+`OUTPUT` edge of a processing operation whose input edges identify every
+normalized source file. A duplicated value must equal its declared source and
+unit conversion exactly; disagreement invalidates the export and blocks
+commissioning readiness. Export is prohibited unless
+`campaign_mapping_status=LOCKED_PUCKWORKS_CAMPAIGN`.
+
+| Locked template and field | Authoritative normalized source or exact rule |
+|---|---|
+| `campaign_metadata.yml.campaign_id` | `campaigns.puckworks_campaign_id` |
+| `.site_id` | `campaigns.site_id` |
+| `.contributor` | `resources.definition` for `campaigns.contributor_resource_id` |
+| `.dataset_status` | `proposal_only` before acquisition; otherwise `pilot_collected` for pilot-only partitions, `holdout_reserved` for unopened Route-B scoring partitions, and `controlled_dataset` for other controlled acquired partitions |
+| `.evidence_level_claimed` | `feasibility_pilot` for pilot evidence; `controlled_replicated` for controlled comparison/calibration; `holdout_independent` only for an authorized opened Route-B score; no upgrade is implied |
+| `.external_repository`, `.doi` | exact `external_repository` and `doi` members of the `EXTERNAL_REPOSITORY` resource referenced by `campaigns.external_repository_resource_id` |
+| `.data_license` | exact `license` member of the `RIGHTS` resource referenced through the selected route and partitions |
+| `.timezone` | `campaigns.timezone` |
+| `.replicate_count` | count of distinct `replicates.replicate_id` for `campaign_instance_id` |
+| `.exclusions_recorded` | boolean existence of excluded shots for the instance, reconciled with exported `exclusions.csv` |
+| `.deviations_from_protocol` | `resources.definition` for `campaigns.deviations_resource_id` |
+| `.declaration.*` | literal `true` only after the corresponding rights and no-upgrade assertions are verified; otherwise export is prohibited |
+
+| `apparatus.yml` field | Authoritative normalized source |
+|---|---|
+| `apparatus_id` | `apparatus.apparatus_id` |
+| `machine_make_model`, `grinder_make_model`, `burr_geometry`, `burr_wear_state`, `basket_geometry` | `resources.definition` from the correspondingly named apparatus resource field |
+| `signals[].observable` | `apparatus_signals.observable_code` |
+| `signals[].instrument` | `resources.definition` for `apparatus_signals.sensor_resource_id` |
+| `signals[].native_unit` | `apparatus_signals.native_unit` |
+| `signals[].native_sampling_rate` | reciprocal of `apparatus_signals.native_sample_interval_s`, with the operation and conversion retained |
+| `signals[].calibration` | calibration IDs linked to the signal; `NOT_APPLICABLE` only when `calibration_applicability=NOT_APPLICABLE` |
+| `signals[].uncertainty` | `resources.definition` for `apparatus_signals.uncertainty_resource_id` |
+| `signals[].clock_source` | `resources.definition` for `apparatus_signals.clock_resource_id` |
+| `signals[].synchronization_method` | `apparatus_signals.synchronization_method` |
+| `signals[].offset_drift_estimate` | `resources.definition` for `apparatus_signals.offset_drift_resource_id` |
+| `signals[].prescribed_or_measured` | `apparatus_signals.prescribed_or_measured` |
+
+| `shot_metadata.csv` field | Authoritative normalized source |
+|---|---|
+| `campaign_id` | `campaigns.puckworks_campaign_id`, never `campaign_instance_id` |
+| `site_id`, `apparatus_id` | campaign and shot local authoritative IDs |
+| `coffee_lot_id`, `grinder_id`, `basket_id` | exact resource IDs from the shot |
+| `shot_id`, `replicate_id`, `dose_g`, `target_beverage_g`, `brew_temperature_c`, `raw_or_processed`, `exclusion_reason` | same-named authoritative shot fields |
+| `achieved_beverage_g` | authoritative final `DELIVERED_MASS_G` signal sample for the shot |
+| `grinder_setting` | exact `grinder_setting` member of `resources.definition` for `shots.grinder_resource_id` |
+| `included` | `true` only for `inclusion_status=INCLUDED`; otherwise `false` |
+
+| `shot_timeseries.csv` field | Authoritative normalized source/conversion |
+|---|---|
+| `shot_id` | `signals.shot_id` |
+| `elapsed_s` | selected `signals.elapsed_time_s` synchronized timebase |
+| `pressure_bar` | basket-top `signals.canonical_value` in Pa gauge divided by exactly `100000` |
+| `pressure_source` | basket signal ID, source-file ID, calibration ID, and processing ID serialized deterministically |
+| `beverage_mass_g` | `DELIVERED_MASS_G` authoritative canonical observation converted to g if needed |
+| `flow_g_s` | authoritative mass-flow signal, or authoritative volume flow converted by the referenced flow-conversion/density record |
+| `flow_source` | signal/conversion/source-file/processing identifiers serialized deterministically |
+| `temperature_c` | authoritative temperature signal converted to degrees Celsius |
+| `raw_or_processed` | authoritative exported signal row state |
+
+Separate upstream pressure remains only in the normalized extension because
+the locked `shot_timeseries.csv` has no upstream-pressure column.
+
+| Remaining locked template | Exact field-level export rule |
+|---|---|
+| `calibration.csv` | `apparatus_id`, `observable`, `unit`, `calibration_datetime_utc`, `calibration_method`, `offset`, and `scale` come from same-named calibration fields (with `observable_code` and `native_unit` name mapping); `instrument` is the sensor resource definition; `notes` deterministically records range, resolution, bandwidth, latency, drift, uncertainty resource, validity interval, and calibration ID |
+| `exclusions.csv` | `campaign_id=campaigns.puckworks_campaign_id`; `shot_id` and `replicate_id` from the shot; `exclusion_reason` from the shot; `recorded_by` from the applicable operator-role resource |
+| `file_manifest.csv` | `filename=files.relative_filename`, `role=files.file_role`, `raw_or_processed`, `sha256`, and `bytes=byte_count`; `license` from the rights resource; `notes` deterministically records `source_file_id`, `parent_source_file_id`, `campaign_instance_id`, and producing processing edge if any |
+| `chemistry_measurements.csv` | when applicable, `campaign_id=campaigns.puckworks_campaign_id`; `shot_id`, `fraction_id`, `species`, `mass_mg`, `reference_basis`, `detection_limit_mg`, `recovery_pct`, and `measurement_status` from chemistry; `analytical_method` from its resource. When no chemistry is acquired, the file is declared `NOT_APPLICABLE` and is not fabricated |
 
 ### Primary and candidate keys
 
 | Table | Unique key used by references |
 |---|---|
 | evidence routes | (`route_id`) |
-| campaigns | (`campaign_id`); candidate (`campaign_id`, `route_id`); candidate (`campaign_id`, `apparatus_id`) |
-| evidence partitions | (`evidence_partition_id`); candidate (`evidence_partition_id`, `campaign_id`, `route_id`) |
-| conditions | (`condition_id`); candidate (`condition_id`, `campaign_id`, `apparatus_id`) |
-| blocks | (`block_id`); candidate (`block_id`, `campaign_id`) |
-| replicates | (`replicate_id`); candidate (`replicate_id`, `campaign_id`, `route_id`, `condition_id`, `block_id`, `evidence_partition_id`) |
-| shots | (`shot_id`); candidate (`shot_id`, `campaign_id`, `route_id`, `condition_id`, `apparatus_id`, `replicate_id`, `block_id`, `evidence_partition_id`) |
+| sites | (`site_id`) |
+| apparatus | (`apparatus_id`); candidate (`apparatus_id`, `site_id`) |
+| apparatus signals | (`apparatus_id`, `signal_id`) |
+| campaigns | (`campaign_instance_id`); candidate (`campaign_instance_id`, `route_id`); candidate (`campaign_instance_id`, `apparatus_id`) |
+| evidence partitions | (`evidence_partition_id`); candidate (`evidence_partition_id`, `campaign_instance_id`, `route_id`) |
+| conditions | (`condition_id`); candidate (`condition_id`, `campaign_instance_id`, `apparatus_id`) |
+| blocks | (`block_id`); candidate (`block_id`, `campaign_instance_id`) |
+| replicates | (`replicate_id`); candidate (`replicate_id`, `campaign_instance_id`, `route_id`, `condition_id`, `block_id`, `evidence_partition_id`) |
+| shots | (`shot_id`); candidate (`shot_id`, `campaign_instance_id`, `route_id`, `condition_id`, `apparatus_id`, `replicate_id`, `block_id`, `evidence_partition_id`) |
 | resources | (`resource_id`) globally unique |
 | signals | (`shot_id`, `signal_id`, `sample_index`) |
 | controls | (`shot_id`, `control_sample_index`) |
 | flow conversions | (`conversion_id`) |
 | deformation | (`shot_id`, `location_id`, `sample_index`) |
+| chemistry | (`shot_id`, `fraction_id`, `species`) |
 | calibrations | (`calibration_id`) |
 | files | (`source_file_id`) |
-| processing lineage | (`processing_id`) |
+| processing operations | (`processing_id`) |
+| processing file edges | (`processing_id`, `edge_role`, `source_file_id`) |
 
 ### Foreign-key resolution matrix
 
@@ -241,28 +338,36 @@ exactly one parent; `NULLABLE` states the sole permitted null condition.
 
 | Child field | Exact parent | Cardinality/null rule |
 |---|---|---|
-| `campaigns.puckworks_campaign_id` | locked catalog `docs/data_requests/experimental_campaigns.yml` `$.campaigns[*].campaign_id` | many-to-one, `NOT NULL` |
-| `campaigns.site_id` | future submitted `campaign_metadata.yml` `$.site_id`, conforming to locked `docs/data_requests/templates/campaign_metadata.yml` | many-to-one, `NOT NULL`; template placeholder is never a parent value |
-| `campaigns.apparatus_id`, `conditions.apparatus_id`, `shots.apparatus_id`, `calibrations.apparatus_id` | future submitted `apparatus.yml` `$.apparatus_id`, conforming to locked `docs/data_requests/templates/apparatus.yml` | many-to-one, `NOT NULL`; template placeholder is never a parent value |
+| `campaigns.puckworks_campaign_id` | locked catalog `docs/data_requests/experimental_campaigns.yml` `$.campaigns[*].campaign_id` | many-to-one; `NOT NULL` only for `campaign_mapping_status=LOCKED_PUCKWORKS_CAMPAIGN`, otherwise null |
+| `campaigns.site_id` | `val_data_001_sites.csv.site_id` | many-to-one, `NOT NULL`; exported to the future template instance |
+| `campaigns.apparatus_id`, `conditions.apparatus_id`, `shots.apparatus_id`, `calibrations.apparatus_id`, `apparatus_signals.apparatus_id` | `val_data_001_apparatus.csv.apparatus_id` | many-to-one, `NOT NULL`; exported to the future template instance |
+| `apparatus.site_id` | `val_data_001_sites.csv.site_id` | many-to-one, `NOT NULL` |
 | `campaigns.route_id`, `evidence_partitions.route_id` | `val_data_001_evidence_routes.csv.route_id` | many-to-one, `NOT NULL` |
-| `evidence_partitions.campaign_id`, `replicates.campaign_id`, `blocks.campaign_id`, `conditions.campaign_id`, `shots.campaign_id` | `val_data_001_campaigns.csv.campaign_id` | many-to-one, `NOT NULL` |
-| `evidence_partitions.(campaign_id, route_id)` | `val_data_001_campaigns.csv.(campaign_id, route_id)` | many-to-one, both `NOT NULL` |
-| `replicates.(condition_id, campaign_id)` | `val_data_001_conditions.csv.(condition_id, campaign_id)` | many-to-one, both `NOT NULL` |
-| `replicates.(block_id, campaign_id)` | `val_data_001_blocks.csv.(block_id, campaign_id)` | many-to-one, both `NOT NULL` |
-| `replicates.(evidence_partition_id, campaign_id, route_id)` | `val_data_001_evidence_partitions.csv.(evidence_partition_id, campaign_id, route_id)` | many-to-one, all `NOT NULL` |
-| `shots.(replicate_id, campaign_id, route_id, condition_id, block_id, evidence_partition_id)` | corresponding six fields of the replicate candidate key | many-to-one, all `NOT NULL` |
-| `shots.(condition_id, campaign_id, apparatus_id)` | condition candidate key | many-to-one, all `NOT NULL` |
-| `signals.shot_id`, `controls.shot_id`, `flow_conversions.shot_id`, `deformation.shot_id` | `val_data_001_shots.csv.shot_id` | many-to-one, `NOT NULL` |
-| every `source_file_id`, `input_source_file_id`, `output_source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one, `NOT NULL` |
+| `evidence_partitions.campaign_instance_id`, `replicates.campaign_instance_id`, `blocks.campaign_instance_id`, `conditions.campaign_instance_id`, `shots.campaign_instance_id`, `files.campaign_instance_id` | `val_data_001_campaigns.csv.campaign_instance_id` | many-to-one, `NOT NULL` |
+| `evidence_partitions.(campaign_instance_id, route_id)` | `val_data_001_campaigns.csv.(campaign_instance_id, route_id)` | many-to-one, both `NOT NULL` |
+| `replicates.(condition_id, campaign_instance_id)` | `val_data_001_conditions.csv.(condition_id, campaign_instance_id)` | many-to-one, both `NOT NULL` |
+| `replicates.(block_id, campaign_instance_id)` | `val_data_001_blocks.csv.(block_id, campaign_instance_id)` | many-to-one, both `NOT NULL` |
+| `replicates.(evidence_partition_id, campaign_instance_id, route_id)` | `val_data_001_evidence_partitions.csv.(evidence_partition_id, campaign_instance_id, route_id)` | many-to-one, all `NOT NULL` |
+| `shots.(replicate_id, campaign_instance_id, route_id, condition_id, block_id, evidence_partition_id)` | corresponding six fields of the replicate candidate key | many-to-one, all `NOT NULL` |
+| `shots.(condition_id, campaign_instance_id, apparatus_id)` | condition candidate key | many-to-one, all `NOT NULL` |
+| `signals.shot_id`, `controls.shot_id`, `flow_conversions.shot_id`, `deformation.shot_id`, `chemistry.shot_id` | `val_data_001_shots.csv.shot_id` | many-to-one, `NOT NULL` |
+| `signals.source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one, `NOT NULL` |
+| `controls.source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one, `NOT NULL` |
+| `flow_conversions.source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one, `NOT NULL` |
+| `deformation.source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one, `NOT NULL` |
+| `chemistry.source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one, `NOT NULL` |
+| `calibrations.source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one, `NOT NULL` |
 | `files.parent_source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one; null only for an instrument-native root file |
 | `signals.calibration_id` | `val_data_001_calibrations.csv.calibration_id` | many-to-one; null only when `signals.missing_value_state=NOT_APPLICABLE` and the signal definition requires no calibration |
 | `flow_conversions.calibration_id` | `val_data_001_calibrations.csv.calibration_id` | many-to-one; `NOT NULL` when `flow_conversions.calibration_applicability=APPLICABLE`; null when it is `NOT_APPLICABLE` or `UNKNOWN_PENDING_REVIEW`, with `UNKNOWN_PENDING_REVIEW` blocking readiness |
 | `deformation.calibration_id` | `val_data_001_calibrations.csv.calibration_id` | many-to-one; null only when `deformation.missing_value_state=NOT_APPLICABLE` and the declared deformation method requires no calibration |
-| `signals.processing_id` | `val_data_001_processing_lineage.csv.processing_id` | many-to-one; null only when `signals.raw_or_processed=RAW_NATIVE` |
-| `controls.processing_id` | `val_data_001_processing_lineage.csv.processing_id` | many-to-one; null only when `controls.raw_or_processed=RAW_NATIVE` and `controls.control_deviation_pa` is empty |
-| `flow_conversions.processing_id` | `val_data_001_processing_lineage.csv.processing_id` | many-to-one, `NOT NULL` |
-| `deformation.processing_id` | `val_data_001_processing_lineage.csv.processing_id` | many-to-one; null only when the deformation row is raw and `coffee_bed_displacement_m` is empty; otherwise `NOT NULL` |
-| `files.processing_id` | `val_data_001_processing_lineage.csv.processing_id` | many-to-one; null only for a declared native/root input file |
+| `signals.processing_id` | `val_data_001_processing_operations.csv.processing_id` | many-to-one; null only when `signals.raw_or_processed=RAW_NATIVE` |
+| `controls.processing_id` | `val_data_001_processing_operations.csv.processing_id` | many-to-one; null only when `controls.raw_or_processed=RAW_NATIVE` and `controls.control_deviation_pa` is empty |
+| `flow_conversions.processing_id` | `val_data_001_processing_operations.csv.processing_id` | many-to-one, `NOT NULL` |
+| `deformation.processing_id` | `val_data_001_processing_operations.csv.processing_id` | many-to-one; null only when `deformation.raw_or_processed=RAW_NATIVE` and `coffee_bed_displacement_m` is empty; otherwise `NOT NULL` |
+| `chemistry.processing_id` | `val_data_001_processing_operations.csv.processing_id` | many-to-one; null only for a directly reported native chemistry measurement, otherwise `NOT NULL` |
+| `processing_file_edges.processing_id` | `val_data_001_processing_operations.csv.processing_id` | many-to-one, `NOT NULL` |
+| `processing_file_edges.source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one, `NOT NULL` |
 | `controls.(shot_id, basket_pressure_signal_id, basket_pressure_sample_index)` | `val_data_001_signals.csv.(shot_id, signal_id, sample_index)` | many-to-one, complete reference `NOT NULL` |
 | `controls.(shot_id, upstream_pressure_signal_id, upstream_pressure_sample_index)` | `val_data_001_signals.csv.(shot_id, signal_id, sample_index)` | many-to-one; signal ID and sample index are both present or both absent, and both may be absent only when `controls.upstream_pressure_availability=NOT_MEASURED` |
 
@@ -279,9 +384,22 @@ reference below resolves to one complete parent key. The required parent
 | `evidence_routes.rights_policy_resource_id`, `evidence_partitions.rights_resource_id`, `resources.rights_resource_id`, `files.rights_resource_id` | `RIGHTS` |
 | `evidence_routes.access_policy_resource_id`, `evidence_partitions.access_policy_resource_id` | `ACCESS_POLICY` |
 | `evidence_partitions.custodian_resource_id` | `CUSTODIAN` |
+| `campaigns.contributor_resource_id` | `CONTRIBUTOR` |
+| `campaigns.external_repository_resource_id` | `EXTERNAL_REPOSITORY` |
+| `campaigns.deviations_resource_id` | `DEVIATION_RECORD` |
+| `sites.rights_resource_id` | `RIGHTS` |
+| `apparatus.machine_make_model_resource_id` | `MACHINE_MODEL` |
+| `apparatus.grinder_make_model_resource_id` | `GRINDER_MODEL` |
+| `apparatus.burr_geometry_resource_id` | `BURR_GEOMETRY` |
+| `apparatus.burr_wear_state_resource_id` | `BURR_WEAR_STATE` |
+| `apparatus.basket_geometry_resource_id` | `BASKET_GEOMETRY` |
+| `apparatus_signals.sensor_resource_id` | `SENSOR` |
+| `apparatus_signals.uncertainty_resource_id` | `UNCERTAINTY` |
+| `apparatus_signals.clock_resource_id` | `CLOCK` |
+| `apparatus_signals.offset_drift_resource_id` | `OFFSET_DRIFT` |
 | `blocks.coffee_lot_resource_id`, `shots.coffee_lot_resource_id` | `COFFEE_LOT` |
 | `blocks.grinder_state_resource_id` | `GRINDER_STATE` |
-| `blocks.operator_role_resource_id`, `processing_lineage.operator_role_resource_id` | `OPERATOR_ROLE` |
+| `blocks.operator_role_resource_id`, `processing_operations.operator_role_resource_id` | `OPERATOR_ROLE` |
 | `blocks.apparatus_state_resource_id` | `APPARATUS_STATE` |
 | `blocks.calibration_set_id`, `calibrations.calibration_set_id` | `CALIBRATION_SET` |
 | `conditions.command_program_resource_id`, `controls.command_program_resource_id` | `COMMAND_PROGRAM` |
@@ -297,7 +415,8 @@ reference below resolves to one complete parent key. The required parent
 | `calibrations.reference_resource_id` | `REFERENCE_STANDARD` |
 | `calibrations.uncertainty_resource_id` | `UNCERTAINTY` |
 | `files.creator_software_resource_id` | `SOFTWARE` |
-| `processing_lineage.operation_resource_id` | `OPERATION` |
+| `processing_operations.operation_resource_id` | `OPERATION` |
+| `chemistry.analytical_method_resource_id` | `ANALYTICAL_METHOD` |
 
 `resources.source_file_id` references `files.source_file_id`; it is `NOT NULL`
 when `resources.resource_provenance_mode=SOURCE_FILE_BOUND` and null only when
@@ -323,10 +442,12 @@ as `PUBLIC_DOMAIN` in `resources.definition`.
 | `control_phase` | `PRE_SHOT`; `RAMP`; `PLATEAU`; `TERMINATION`; `POST_SHOT` |
 | `block_type` | `SESSION`; `COFFEE_LOT`; `GRINDER_STATE`; `OPERATOR_STATE`; `APPARATUS_CALIBRATION_STATE` |
 | `location_id` | `UPPER_BED`; `MID_BED`; `LOWER_BED`; `BULK_EQUIVALENT` |
-| `resource_type` | `ACCESS_POLICY`; `APPARATUS_STATE`; `CALIBRATION_SET`; `COMMAND_PROGRAM`; `CUSTODIAN`; `DENSITY_SOURCE`; `FIXTURE_COMPLIANCE`; `FREEZE_IDENTITY`; `GRINDER`; `GRINDER_STATE`; `HUMAN_DISPOSITION`; `HYDRAULIC_INITIAL_STATE`; `OPERATION`; `OPERATOR_ROLE`; `PREPARATION_PROTOCOL`; `REFERENCE_STATE`; `REFERENCE_STANDARD`; `RIGHTS`; `SENSOR`; `SOFTWARE`; `UNCERTAINTY`; `COFFEE_LOT`; `BASKET`; `CLOCK` |
+| `resource_type` | `ACCESS_POLICY`; `ANALYTICAL_METHOD`; `APPARATUS_STATE`; `BASKET`; `BASKET_GEOMETRY`; `BURR_GEOMETRY`; `BURR_WEAR_STATE`; `CALIBRATION_SET`; `CLOCK`; `COFFEE_LOT`; `COMMAND_PROGRAM`; `CONTRIBUTOR`; `CUSTODIAN`; `DENSITY_SOURCE`; `DEVIATION_RECORD`; `EXTERNAL_REPOSITORY`; `FIXTURE_COMPLIANCE`; `FREEZE_IDENTITY`; `GRINDER`; `GRINDER_MODEL`; `GRINDER_STATE`; `HUMAN_DISPOSITION`; `HYDRAULIC_INITIAL_STATE`; `MACHINE_MODEL`; `OFFSET_DRIFT`; `OPERATION`; `OPERATOR_ROLE`; `PREPARATION_PROTOCOL`; `REFERENCE_STATE`; `REFERENCE_STANDARD`; `RIGHTS`; `SENSOR`; `SOFTWARE`; `UNCERTAINTY` |
 | `upstream_pressure_availability` | `MEASURED`; `NOT_MEASURED`; `SENSOR_FAILURE` |
 | `calibration_applicability` | `APPLICABLE`; `NOT_APPLICABLE`; `UNKNOWN_PENDING_REVIEW` |
 | `resource_provenance_mode` | `INLINE_DECLARATION`; `SOURCE_FILE_BOUND` |
+| `campaign_mapping_status` | `LOCKED_PUCKWORKS_CAMPAIGN`; `PUCKWORKS_MACHINE_MODE_CAMPAIGN_GAP_LOCAL_EXTENSION`; `FUTURE_PUCKWORKS_CAMPAIGN_PENDING` |
+| `edge_role` | `INPUT`; `OUTPUT` |
 
 ### Route-conditional partition representation
 
@@ -349,7 +470,7 @@ as `PUBLIC_DOMAIN` in `resources.definition`.
   `calibration_evidence_class=RECONSTRUCTION_OR_CALIBRATION` and
   `scoring_evidence_class=HOLDOUT_OR_TRANSFER`.
 - `SEPARATE_CHARACTERIZATION_THEN_INDEPENDENT_VALIDATION`: two distinct
-  `campaign_id` values are required. The first has a `CHARACTERIZATION`
+  `campaign_instance_id` values are required. The first has a `CHARACTERIZATION`
   partition with `evidence_class=CHARACTERIZATION`; the later campaign has a
   wholly untouched `COMPARISON` partition with
   `evidence_class=INDEPENDENT_COMPONENT_VALIDATION`. The later campaign is not
@@ -385,20 +506,47 @@ If duplicated presentation values are exported later, they must be byte- and
 value-derived from that signal row; conflicts resolve in favor of the signal
 table and invalidate the export.
 
+### Processing operation and edge-graph invariants
+
+1. Every `processing_operations.processing_id` has at least one `INPUT` and
+   one `OUTPUT` row in `processing_file_edges`; multiple inputs and outputs are
+   permitted and ordered independently by `edge_sequence` within each role.
+2. Every edge resolves to one operation and one
+   `files.source_file_id`. The edge primary key prevents duplicate file/role
+   membership in an operation.
+3. Every processed or derived signal, control value, flow conversion,
+   deformation value, chemistry value, or compatibility export references its
+   producing operation. The output file containing that value has exactly one
+   `OUTPUT` edge for that operation.
+4. Each output file has exactly one producing operation across the entire edge
+   table. Native/root files have `raw_or_processed=RAW_NATIVE`, have no
+   `OUTPUT` edge, and may appear only as inputs.
+5. The directed graph from input files through operations to output files is
+   acyclic. A deterministic topological sort over files and operations must
+   include every node; a cycle or orphan processed file invalidates the
+   submission.
+6. Synchronization may consume multiple channel files, and one operation may
+   emit synchronized signals, controls, conversions, and compatibility exports
+   as separate output files without losing shared provenance.
+7. Every compatibility export field above is recomputed from its authoritative
+   normalized source during verification. Exported/local disagreement,
+   missing input edges, or ambiguous producing operations invalidate the
+   export.
+
 ### Cross-table relational invariants
 
-1. `evidence_partitions.(campaign_id, route_id)` must match the campaign
+1. `evidence_partitions.(campaign_instance_id, route_id)` must match the campaign
    candidate key; existence of each identifier separately is insufficient.
-2. A replicate's (`condition_id`, `campaign_id`) and (`block_id`,
-   `campaign_id`) must match the corresponding condition and block candidate
+2. A replicate's (`condition_id`, `campaign_instance_id`) and (`block_id`,
+   `campaign_instance_id`) must match the corresponding condition and block candidate
    keys.
-3. A replicate's (`evidence_partition_id`, `campaign_id`, `route_id`) must
-   match one partition candidate key, and its (`campaign_id`, `route_id`) must
+3. A replicate's (`evidence_partition_id`, `campaign_instance_id`, `route_id`) must
+   match one partition candidate key, and its (`campaign_instance_id`, `route_id`) must
    match its campaign.
 4. A shot's duplicated campaign, route, condition, block, and partition fields
    must exactly equal those inherited through the complete replicate candidate
-   key. Its (`condition_id`, `campaign_id`, `apparatus_id`) must also match the
-   condition candidate key, and its apparatus must equal the campaign's
+   key. Its (`condition_id`, `campaign_instance_id`, `apparatus_id`) must also match the
+   condition candidate key, and its apparatus must equal the campaign instance's
    apparatus. Any mismatch rejects the row.
 5. Every referenced pressure sample has the same `shot_id` as the control row.
    For `control_mode=PRESCRIBED_BASKET_PRESSURE`, the condition and every
@@ -410,6 +558,12 @@ table and invalidate the export.
 7. Route-specific partition roles, evidence classes, and sealing states must
    satisfy the selected route rules below. Ordinary replicates and blocks do
    not acquire holdout status independently of their partition.
+8. Every local row carries or inherits exactly one `campaign_instance_id`.
+   `puckworks_campaign_id` is never used as a local relational key.
+9. `campaign_mapping_status=LOCKED_PUCKWORKS_CAMPAIGN` requires a catalog-valid
+   non-null `puckworks_campaign_id`. Both gap/pending statuses require it to be
+   null and prohibit compatibility export. The mapping status and selected
+   route are frozen before commissioning.
 
 ## Timebase, timing, calibration, and latency
 

--- a/docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md
+++ b/docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md
@@ -427,11 +427,19 @@ two quality-eligible samples; extrapolation is prohibited. Missing values use
 `time_source_mode=MISSING`, `source_count=0`, no child rows, an empty exported value,
 and an explicit missing state.
 
-`exported_row_state` is frozen for the complete output row. An output row may
-use exact and interpolated values only from compatible
-`PROCESSED_SYNCHRONIZED` or `DERIVED` states declared by the export contract;
+`exported_row_state` is frozen for the complete output row. Its total mapping
+is `RAW_NATIVE -> raw`, `PROCESSED_SYNCHRONIZED -> processed`, and
+`DERIVED_WITH_SYNCHRONIZED_SOURCES -> processed`. `RAW_NATIVE` is permitted
+only where the specific locked-template contract prospectively allows a
+raw-native compatibility row. An output row may use exact and interpolated
+values only from compatible states declared by the export contract;
 raw-native and synchronized values are never silently combined. Every child
 retains its source `raw_or_processed` state and value-processing identity.
+`MISSING_DECLARED` is not a row provenance state: missingness remains solely
+in `missing_value_state`, while the complete row retains its actual raw,
+processed, or derived provenance. Every field sharing one
+`shot_timeseries.csv` row key has that same state and therefore the same one
+Puckworks `raw` or `processed` scalar.
 `flow_conversion_id` is non-null only when flow/density or mass-flow/
 volume-flow conversion participates. Fixed scale/offset conversions use no
 flow row. `unit_conversion_mode` is `NONE`, `FIXED_SCALE_OFFSET`, or
@@ -637,10 +645,26 @@ no leading dot. The sole sequence form is
 `signals[signal_id=<canonical-id>].<member>`; indices and wildcards are
 prohibited, so every nested value has one stable path.
 
-The compatibility mapping is frozen: `RAW_NATIVE -> raw`,
-`PROCESSED_SYNCHRONIZED -> processed`, and `DERIVED -> processed`. It applies
-to every Puckworks `raw_or_processed` field. Missingness never changes row
-provenance, and `MISSING_DECLARED` is never emitted there.
+Both YAML files use one byte-deterministic emitter profile: UTF-8 without BOM;
+LF line endings with exactly one final LF; no document marker, anchors,
+aliases, tags, comments, trailing whitespace, or trailing blank lines;
+two-space indentation; block-style `signals`; one space after every mapping
+colon; the frozen key and sequence order above; and double-quoted YAML 1.2
+strings with JSON escaping. For `apparatus.yml`, applicability `APPLICABLE`
+emits the exact bytes `calibration: "see calibration.csv"`,
+`NOT_APPLICABLE` emits `calibration: "NOT_APPLICABLE"`, and
+`UNKNOWN_PENDING_REVIEW` prohibits export. Calibration identifiers and
+validity intervals remain solely in the normalized calibration table and
+`calibration.csv`.
+
+The normalized compatibility mapping is frozen: `RAW_NATIVE -> raw`,
+`PROCESSED_SYNCHRONIZED -> processed`, and `DERIVED -> processed`. The
+time-series exported-row mapping is `RAW_NATIVE -> raw`,
+`PROCESSED_SYNCHRONIZED -> processed`, and
+`DERIVED_WITH_SYNCHRONIZED_SOURCES -> processed`. These mappings are total for
+every Puckworks `raw_or_processed` field. Missingness never changes row
+provenance, and `MISSING_DECLARED` is neither a valid `exported_row_state` nor
+emitted into `raw_or_processed`.
 
 The deterministic audit fails unless every resource member exists with its
 declared type, every file has the closed schema and source contract, all YAML
@@ -683,7 +707,7 @@ commissioning readiness. Export is prohibited unless
 | `signals[].instrument` | `SENSOR.display_text` for `apparatus_signals.sensor_resource_id` |
 | `signals[].native_unit` | `apparatus_signals.native_unit` |
 | `signals[].native_sampling_rate` | reciprocal of `apparatus_signals.native_sample_interval_s`, with the operation and conversion retained |
-| `signals[].calibration` | calibration IDs linked to the signal; `NOT_APPLICABLE` only when `calibration_applicability=NOT_APPLICABLE` |
+| `signals[].calibration` | `APPLICABLE`: exact YAML string `"see calibration.csv"`; `NOT_APPLICABLE`: exact YAML string `"NOT_APPLICABLE"`; `UNKNOWN_PENDING_REVIEW`: export prohibited. Actual IDs and validity remain in normalized calibrations and `calibration.csv` and are never serialized as a variable list here |
 | `signals[].uncertainty` | `UNCERTAINTY.display_text` for `apparatus_signals.uncertainty_resource_id` |
 | `signals[].clock_source` | `CLOCK.display_text` for `apparatus_signals.clock_resource_id` |
 | `signals[].synchronization_method` | `apparatus_signals.synchronization_method` |
@@ -802,7 +826,7 @@ exactly one parent; `NULLABLE` states the sole permitted null condition.
 | `files.(evidence_partition_id, campaign_instance_id)` | `val_data_001_evidence_partitions.csv.(evidence_partition_id, campaign_instance_id)` | many-to-one, both `NOT NULL`; partition route must agree with campaign |
 | `compatibility_packages.(evidence_partition_id, campaign_instance_id, route_id)` | `val_data_001_evidence_partitions.csv.(evidence_partition_id, campaign_instance_id, route_id)` | many-to-one, all `NOT NULL`; one partition per package |
 | `compatibility_packages.puckworks_campaign_id` | `val_data_001_campaigns.csv.puckworks_campaign_id` through the package `campaign_instance_id` | exact equality; `NOT NULL` for an exportable locked mapping, otherwise package export prohibited |
-| `compatibility_packages.export_processing_id` | `val_data_001_processing_operations.csv.processing_id` | required for `FULL_COMPATIBILITY_EXPORT` and `METADATA_CHECKSUM_ONLY`, null for `NOT_GENERATED` and `NOT_APPLICABLE`; non-null parent scope exactly `COMPATIBILITY_EXPORT` |
+| `compatibility_packages.export_processing_id` | `val_data_001_processing_operations.csv.processing_id` | `FULL_COMPATIBILITY_EXPORT`: required with parent scope exactly `COMPATIBILITY_EXPORT`; `METADATA_CHECKSUM_ONLY`: required with parent scope exactly `SEALED_METADATA_ASSEMBLY`; `NOT_GENERATED` and `NOT_APPLICABLE`: null |
 | `compatibility_packages.export_grid_id`, `export_grids.(export_grid_id, compatibility_package_id)` | reciprocal package/grid keys | exactly one for `FULL_COMPATIBILITY_EXPORT`; null/no row for all other modes |
 | `export_grids.compatibility_package_id`, `export_source_rows.compatibility_package_id` | `val_data_001_compatibility_packages.csv.compatibility_package_id` | many-to-one, `NOT NULL` |
 | `export_source_rows.export_processing_id` | `val_data_001_processing_operations.csv.processing_id` | `NOT NULL`, equals its package export operation, scope exactly `COMPATIBILITY_EXPORT` |
@@ -927,13 +951,13 @@ null rights reference.
 | `edge_role` | `INPUT`; `OUTPUT` |
 | `operation_scope` | `ROW_VALUE`; `NORMALIZED_FILE_ASSEMBLY`; `COMPATIBILITY_EXPORT`; `SEALED_METADATA_ASSEMBLY` |
 | `package_access_status` | `OPEN_AUTHORIZED`; `CALIBRATION_ACCESS`; `SEALED_UNACCESSED`; `AUTHORIZED_OPENED`; `CLOSED_AFTER_SCORING`; `PUBLIC_METADATA_ONLY` |
-| `export_status` | `NOT_GENERATED`; `GENERATED_VERIFIED`; `PROHIBITED_SEALED`; `NOT_APPLICABLE` |
+| `export_status` | `NOT_GENERATED`; `GENERATED_VERIFIED`; `NOT_APPLICABLE` |
 | `fraction_chemistry_status` | `PRESENT`; `NOT_APPLICABLE_NO_FRACTIONATED_CHEMISTRY` |
 | `package_content_mode` | `FULL_COMPATIBILITY_EXPORT`; `METADATA_CHECKSUM_ONLY`; `NOT_GENERATED`; `NOT_APPLICABLE` |
 | `provenance_class` | `NORMALIZED_RECORD`; `TIME_INDEXED_SAMPLES`; `FROZEN_LITERAL` |
 | `time_source_mode` | `EXACT_SAMPLE`; `LINEAR_INTERPOLATION`; `MISSING`; null for non-time provenance |
 | `unit_conversion_mode` | `NONE`; `FIXED_SCALE_OFFSET`; `FLOW_DENSITY_CONVERSION` |
-| `exported_row_state` | `PROCESSED_SYNCHRONIZED`; `DERIVED_WITH_SYNCHRONIZED_SOURCES`; `MISSING_DECLARED`; null only for non-time compatibility filenames |
+| `exported_row_state` | `RAW_NATIVE` only where the template prospectively permits raw-native presentation; `PROCESSED_SYNCHRONIZED`; `DERIVED_WITH_SYNCHRONIZED_SOURCES`; null only for non-time compatibility filenames |
 | `event_status` | `OBSERVED`; `DERIVED`; `MISSING`; `AMBIGUOUS_RETAINED` |
 
 ### Route-conditional partition representation
@@ -1015,11 +1039,15 @@ table and invalidate the export.
 6. Synchronization is a `ROW_VALUE` operation and may consume multiple native
    channel files, but it emits only row-value artifacts. A distinct
    `NORMALIZED_FILE_ASSEMBLY` operation consumes those artifacts and emits
-   complete authoritative normalized tables. A third, distinct
-   `COMPATIBILITY_EXPORT` operation consumes verified normalized tables and
-   emits only Puckworks compatibility files. Edges between layer outputs and
-   subsequent layer inputs preserve shared provenance; one operation never
-   spans layers.
+   complete authoritative normalized tables. From that layer exactly one of
+   two export branches is permitted per generated package:
+   `NORMALIZED_FILE_ASSEMBLY -> COMPATIBILITY_EXPORT` for full Puckworks
+   presentation, or
+   `NORMALIZED_FILE_ASSEMBLY -> SEALED_METADATA_ASSEMBLY` for the sealed
+   metadata envelope. The sealed branch consumes only package, partition,
+   terminal-rights, access-policy, seal, and checksum inputs and emits only
+   `package_manifest.json`, `rights_access.json`, and `seal_identity.json`.
+   Edges preserve provenance; no operation or package spans or mixes branches.
 7. Every compatibility export field above is recomputed from its authoritative
    normalized source during verification. Exported/local disagreement,
    missing input edges, or ambiguous producing operations invalidate the
@@ -1029,8 +1057,10 @@ table and invalidate the export.
    `NORMALIZED_FILE_ASSEMBLY` consumes row-value artifacts and produces only
    complete authoritative normalized submission tables.
    `COMPATIBILITY_EXPORT` consumes verified normalized files and produces only
-   the partition-specific Puckworks presentation. Scope mixing invalidates the
-   graph.
+   the partition-specific Puckworks presentation.
+   `SEALED_METADATA_ASSEMBLY` consumes only the restricted normalized metadata
+   inputs above and produces only the three sealed-envelope JSON files. Scope
+   or output mixing invalidates the graph.
 9. No file-to-file parent column supplies provenance. Reachability, complete
    input multiplicity, the unique producer, software identity, parameters,
    and output identity are reconstructed exclusively from operation rows and

--- a/docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md
+++ b/docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md
@@ -3,8 +3,7 @@
 **Task class:** `EXPERIMENTAL_DESIGN_AND_DATA_REQUEST_PLANNING`  
 **Change declaration:** `NO_GOVERNING_PHYSICS_CHANGE`  
 **Status:** `COMMISSIONING_NOT_AUTHORIZED`  
-**Evidence class intended for a future separately authorized case:**
-`INDEPENDENT_COMPONENT_VALIDATION`  
+**Future evidence route:** `HUMAN_OWNER_PROSPECTIVE_SELECTION_REQUIRED`
 **Claim ceiling:** `VALIDATION_SUPPORT_ONLY_PHYSICAL_VALIDATION_NOT_ESTABLISHED`
 
 This document is an implementation-ready planning input for a later human
@@ -25,6 +24,21 @@ considered only after reproducible, uncertainty-aware residual structure
 remains across independent conditions and cannot be explained by preparation,
 apparatus, boundary-node, calibration, or existing-model uncertainty. A fit
 improvement alone would not justify new physics.
+
+## Prospective evidence route
+
+The human owner must select and freeze one route before commissioning. Pilot
+data are non-validation evidence by default. Ordinary comparison replicates
+must not be called holdout evidence, and one observation must never both fit a
+parameter and support an independent comparison of that fitted response.
+
+| Route | Access and leakage control | Rights and claim consequence |
+|---|---|---|
+| Independent dataset unused for fitting: `INDEPENDENT_COMPONENT_VALIDATION` | All scored observations remain inaccessible to calibration and model selection; pilot and characterization evidence are separate. Access must be logged and independence frozen prospectively. | Rights must permit the comparison and reported products. The result can support only a bounded independent component-validation claim under separate authority, never general physical validation. |
+| Calibration subset plus sealed scoring subset: `RECONSTRUCTION_OR_CALIBRATION` followed by `HOLDOUT_OR_TRANSFER` | Partition identities and hashes are frozen before fitting. Calibration access and later sealed-subset access are separate activities; holdout access, leakage controls, and scoring require separate authority. | Rights must cover both uses. Calibration results are not independent validation; only the untouched partition may support a later bounded holdout/transfer disposition. |
+| Separate characterization/calibration campaign followed by a separately commissioned untouched dataset | Pilot and characterization records may inform apparatus and calibration, but the later dataset is separately commissioned, access-controlled, and untouched until its prospective comparison protocol is frozen. | Rights and custody must independently cover both campaigns. Only the later untouched dataset may be considered for `INDEPENDENT_COMPONENT_VALIDATION`. |
+
+Final route disposition: `HUMAN_OWNER_PROSPECTIVE_SELECTION_REQUIRED`.
 
 ## Campaign crosswalk
 
@@ -66,15 +80,53 @@ detected physical liquid at the defined outlet plane.
 
 | Condition | Status | Control and measured nodes | Required role fields |
 |---|---|---|---|
-| Prescribed 5 bar | Required | prescribed boundary target; independently measured basket-top pressure, outlet flow/mass, and deformation | preparation, common origin, calibration state, replicate/block ID, comparison/holdout role |
-| Prescribed 9 bar | Required | same nodes and metadata as 5 bar | primary mid-range discrimination condition |
-| Machine-coupled shot | Required | measured machine-side pressure upstream of `Ru` and separate basket-top pressure, outlet flow/mass, deformation | machine response plus all common metadata |
-| Prescribed 11 bar | Optional model-form stress condition | same prescribed-condition nodes | must not be treated as sufficient alone for local compaction discrimination |
+| Prescribed 5 bar | Required | `P_BASKET_BED_TOP_PA_GAUGE = 500000 Pa gauge`; record commanded waveform separately from achieved basket-top pressure | preparation, common origin, calibration state, replicate/block ID, prospectively frozen analysis role |
+| Prescribed 9 bar | Required | `P_BASKET_BED_TOP_PA_GAUGE = 900000 Pa gauge`; record commanded waveform separately from achieved basket-top pressure | primary mid-range discrimination condition |
+| Machine-coupled shot | Required | basket-top pressure is measured, not prescribed; record separate machine-side and basket-top pressure outputs | complete machine command/control program, initial hydraulic state, and all common metadata |
+| Prescribed 11 bar | Optional model-form stress condition | `P_BASKET_BED_TOP_PA_GAUGE = 1100000 Pa gauge`; record commanded waveform separately from achieved basket-top pressure | must not be treated as sufficient alone for local compaction discrimination |
 
 Actual control accuracy and apparatus feasibility remain
 `APPARATUS_FEASIBILITY_REQUIRED`. Every run must bind its condition ID,
 replicate ID, randomized order, preparation block, sensor/calibration IDs, and
-predeclared comparison or holdout role.
+predeclared evidence partition and analysis role.
+
+For every prescribed-pressure condition, retain distinct fields for the
+command or setpoint waveform, prescribed physical node, achieved measured
+basket-top pressure, upstream measured pressure, ambient reference and zeroing
+basis, and ramp, plateau, termination, control-deviation, and control-status
+histories. Pressure-control tolerance and achievable architecture remain
+`APPARATUS_FEASIBILITY_REQUIRED`; ramp and plateau definitions remain
+`PILOT_REQUIRED`. For the machine-coupled condition, retain the complete
+machine command/control program and initial hydraulic state. Free-flow and
+shutoff characterization remain subject to the prospective parameter-role and
+pilot decisions.
+
+## Parameter and evidence-role ledger
+
+Every final role must be frozen before commissioning. `Unused outputs` below
+must remain unused for fitting if they will support an independent comparison.
+
+| Item; definition and units | Current status and preferred independent source | Campaign/gap and future role | Permitted calibration evidence; unused comparison outputs; holdout restriction | Circularity consequence and unresolved disposition |
+|---|---|---|---|---|
+| `k0`, reference intrinsic permeability (m2) | uncertain model input; independent constant-head/pressure-flow characterization bound to the compared coffee, grinder, packing, and shot | EXP-003; measured input, calibration quantity, or withheld comparison input | Separate characterization may calibrate it; comparison-shot flow/pressure must remain unused if independently scored; sealed records require separate access authority | Fitting from the scored pressure-flow response destroys independence for that response; `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING` |
+| `pc`, compaction pressure scale (Pa) | uncertain model input; independent mechanical pressure/deformation characterization | EXP-004; calibration quantity or withheld compaction parameter | Calibration subset may fit it; withheld pressure/deformation outputs remain untouched; holdout identities sealed prospectively | Fitting and scoring the same deformation curve is circular; `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING` |
+| `phi0`, stress-free/reference porosity (1) | uncertain model input; independent geometry, dose, density, and packing characterization bound to each compared shot | EXP-003; measured input or calibration quantity | Characterization may supply it; compared-shot deformation/flow outputs remain unused for fitting; sealed partitions require separate authority | Inferring it from the scored hydraulic response removes independence; `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING` |
+| `Cu`, machine/upstream compliance (m3/Pa) | uncertain machine input; independent volume-pressure or transient hydraulic characterization | machine-mode campaign gap | Separate machine characterization or declared calibration subset; withheld upstream/basket transient outputs remain unused; no holdout access here | Inferring `Cu` from the same scored transient confounds machine and puck response; `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING` |
+| `Ru`, upstream hydraulic resistance (Pa s/m3) | uncertain machine input; independent line-resistance characterization | machine-mode campaign gap | Separate machine characterization or calibration subset; withheld pressure-drop/flow outputs remain unused; telemetry role must be declared | Telemetry-derived `Ru` cannot independently validate that same pressure-drop response; `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING` |
+| `Qfree`, free-flow supply parameter (m3/s) | uncertain machine input; independent no-puck free-flow characterization | machine-mode campaign gap | Characterization may prescribe it; scored machine/puck flow remains unused; any sealed comparison is separately controlled | Derivation from scored coupled flow creates circular machine-boundary evidence; `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING` |
+| `pshut`, shutoff-pressure supply parameter (Pa gauge) | uncertain machine input; independent safe shutoff/supply-curve characterization | machine-mode campaign gap | Characterization may prescribe it; scored upstream/basket pressures remain unused; sealed access requires separate authority | Derivation from the scored coupled pressure response destroys independence; `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING` |
+| universal/finite-porosity model-form switch (categorical) | existing model-form switch; no fitting source | EXP-004 plus EXP-001 telemetry; future withheld model-form comparison | Calibration/model selection must use only a declared subset; all discriminator outputs in a sealed subset remain untouched | Choosing the branch on scored outputs invalidates independent discrimination; `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING` |
+| viscosity, dynamic viscosity (Pa s) | measured/source-derived input; traceable temperature-dependent fluid property | EXP-001 temperature metadata | Independently prescribed or calculated before comparison; scored flow is not a property-fitting source; sealed output access prohibited | Back-calculating viscosity from scored flow makes hydraulic comparison circular; `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING` |
+| density, fluid density (kg/m3) | measured/source-derived input; traceable gravimetric/volumetric or temperature-dependent property | EXP-001 | Independently prescribed for mass/volume conversion; scored mass and flow remain unused for fitting; provenance travels with partition | Estimating density to reconcile scored mass and volume flow compromises that comparison; `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING` |
+| wetting/first-drip inputs, including dry-bed and inlet/timing quantities (declared native units) | uncertain/measured inputs; independent preparation metadata and physical marker characterization | EXP-002 | Pilot/characterization may define detection and inputs; withheld first-drip timing remains unused; ordinary replicates are not holdouts | Tuning wetting inputs to scored first drip prevents an independent timing claim; `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING` |
+| downstream extraction/dissolution quantities used in a comparison (quantity-specific SI units) | existing inputs/outputs; independent chemistry, dose, and material characterization | EXP-001 and EXP-003 | Only explicitly declared calibration quantities may be fitted; cup chemistry and extraction outputs intended for comparison remain unused and separately partitioned | Fitting against the same chemistry/extraction response precludes independent scoring; `ROLE_FREEZE_REQUIRED_BEFORE_COMMISSIONING` |
+
+When `k0`, `phi0`, PSD, or packing are supplied through EXP-003-style
+characterization, their identifiers and provenance must bind to the exact
+compared shot or declared material/preparation block. When `Cu`, `Ru`,
+`Qfree`, or `pshut` are inferred from telemetry, that telemetry must be labeled
+as calibration, characterization, or sealed comparison evidence before
+access.
 
 ## Model-informed signal targets
 
@@ -91,7 +143,8 @@ claim, or procurement specification.
 | Basket-bottom outlet flow | approximately <= 0.02 mL/s | `SENSOR_SELECTION_REQUIRED`; `PILOT_REQUIRED` |
 | Cumulative delivered mass | approximately <= 0.5 g | `SENSOR_SELECTION_REQUIRED`; `PILOT_REQUIRED` |
 | Bed height/deformation | approximately <= 0.05 mm | `SENSOR_SELECTION_REQUIRED`; `APPARATUS_FEASIBILITY_REQUIRED` |
-| Common synchronization/raw sampling | approximately <= 20 ms | latency study required |
+| Native sample interval, where channel capability supports it | approximately <= 20 ms | `SENSOR_SELECTION_REQUIRED`; bandwidth is separate |
+| Inter-channel synchronization error | approximately <= 20 ms | `PILOT_REQUIRED`; latency is separate |
 | Optional physical first drip | approximately <= 0.02 s | `SENSOR_SELECTION_REQUIRED`; `PILOT_REQUIRED` |
 
 ## Metadata and preparation controls
@@ -105,15 +158,90 @@ distribution, leveling, tamp protocol and force record; operator/automation
 role; timing; and deviations. Real values remain unresolved until authorized
 acquisition.
 
-## Timebase, calibration, and latency
+## Submission data-schema contract
 
-All raw channels require one monotonic elapsed-time basis with an explicit
-physical `t=0` event. If a single hardware clock is unavailable, retain native
-timestamps and document offset, drift, resampling, and latency characterization
-without overwriting raw data. Pre- and post-session calibration records,
-traceability, range, detection limit, hysteresis, drift, zeroing, cross-talk,
-dynamic response, alignment, and clock latency must be retained. Final sensor
-models and calibration procedures remain `SENSOR_SELECTION_REQUIRED`.
+This plan is a read-only extension of the templates under
+`docs/data_requests/templates/` at locked Puckworks commit
+`fc61c4670ec7bf801e40bb391aab16048b8da26b` and tree
+`1d553e44ee2f7480a5df521560801b478618cc84`. It preserves the meanings of
+`campaign_metadata.yml`, `apparatus.yml`, `shot_metadata.csv`,
+`shot_timeseries.csv`, `calibration.csv`, `exclusions.csv`,
+`file_manifest.csv`, and `chemistry_measurements.csv`. Puckworks remains
+unchanged. A future submission must supply those templates plus the following
+normalized VAL-DATA-001 extension files.
+
+Common identifiers are non-empty strings. Primary keys are unique; foreign
+keys must resolve within the same checksum-bound submission. Missing values
+must be empty only when `missing_value_state` is one of `NOT_MEASURED`,
+`NOT_APPLICABLE`, `BELOW_DETECTION`, `SENSOR_FAILURE`, or `MISSING_UNKNOWN`;
+numeric zero is never a missing-value code.
+
+| File/table | Primary key and foreign keys | Required fields and canonical units |
+|---|---|---|
+| `val_data_001_campaign.csv` | PK `campaign_id`; FK `puckworks_campaign_id` to the locked campaign identity | `campaign_id`, `puckworks_campaign_id`, `site_id`, `apparatus_id`, `evidence_partition_id`, `analysis_role`, `rights_id`, `schema_version`; analysis role is one of `PILOT_NON_VALIDATION`, `CHARACTERIZATION`, `CALIBRATION`, `COMPARISON`, `SEALED_HOLDOUT`, or `TRANSFER` |
+| `val_data_001_conditions.csv` | PK `condition_id`; FK `campaign_id`, `apparatus_id` | `control_mode`, `prescribed_node`, `prescribed_pressure_pa_gauge`, `command_program_id`, `initial_hydraulic_state_id`, `ambient_reference_pa`, `zeroing_basis`, `ramp_definition`, `plateau_definition`, `termination_rule`, `control_tolerance_pa`, `missing_value_state` |
+| `val_data_001_shots.csv` | PK `shot_id`; FK `campaign_id`, `condition_id`, `apparatus_id`, `replicate_id`, `block_id`, `evidence_partition_id` | coffee/grinder/basket/dose/preparation/temperature identifiers, randomized order, `raw_or_processed`, `inclusion_status`, `exclusion_reason`, `t0_event_code`, `t0_uncertainty_s`; this extends locked `shot_metadata.csv` rather than changing it |
+| `val_data_001_signals.csv` | composite PK (`shot_id`, `signal_id`, `sample_index`); FK `shot_id`, `sensor_id`, `clock_id`, `calibration_id`, `source_file_id`, optional `parent_processing_id` | `native_timestamp`, `elapsed_time_s`, `native_value`, `native_unit`, `canonical_value`, `canonical_unit`, `physical_node`, `raw_or_processed`, `quality_flags`, `missing_value_state`, `clock_offset_s`, `clock_drift_s_per_s`, `sensor_latency_s`, `resampling_interval_s` |
+| `val_data_001_controls.csv` | composite PK (`shot_id`, `control_sample_index`); FK `shot_id`, `command_program_id`, `clock_id`, `source_file_id` | `native_timestamp`, `elapsed_time_s`, commanded/setpoint value and unit, `prescribed_node`, achieved basket-top pressure in Pa gauge, measured upstream pressure in Pa gauge, ambient reference in Pa, `control_deviation_pa`, `control_status`, ramp/plateau/termination state |
+| `val_data_001_flow_conversion.csv` | PK `conversion_id`; FK `shot_id`, `density_source_id`, optional `calibration_id` | native mass flow in g/s, native volume flow in mL/s when measured, canonical mass flow in kg/s, canonical volume flow in m3/s, density in kg/m3, temperature basis, conversion formula, density provenance, uncertainty record ID |
+| `val_data_001_deformation.csv` | composite PK (`shot_id`, `location_id`, `sample_index`); FK `shot_id`, `sensor_id`, `calibration_id`, `reference_state_id`, `source_file_id` | native/canonical displacement and units, compression sign, `spatial_basis`, axial/radial coordinates, reference state, fixture-compliance correction ID, coffee-bed-only value, quality/missing flags, timing fields |
+| `val_data_001_calibrations.csv` | PK `calibration_id`; FK `apparatus_id`, `sensor_id`, `source_file_id` | observable, native/canonical units, method, reference identity, timestamp, offset, scale, range, resolution, bandwidth, latency, drift, uncertainty-record ID, validity interval; extends locked `calibration.csv` |
+| `val_data_001_files.csv` | PK `source_file_id`; optional FK `parent_source_file_id`, `processing_id` | relative filename, role, `raw_or_processed`, SHA-256, byte count, media type, license/rights ID, creator software identity, transformation identity; extends locked `file_manifest.csv` |
+| `val_data_001_processing_lineage.csv` | PK `processing_id`; FKs to input `source_file_id` values and output `source_file_id` | software commit/tree, command or deterministic operation ID, parameters, input/output hashes, synchronization method, resampling method, operator role, timestamp |
+
+The signal registry must include `P_MACHINE_UPSTREAM_RU_PA_GAUGE`,
+`P_BASKET_BED_TOP_PA_GAUGE`, commanded pressure as a separate control signal,
+`OUTLET_MASS_FLOW_G_S`, `OUTLET_VOLUME_FLOW_ML_S`, `DELIVERED_MASS_G`, and
+location-specific `DEFORMATION_MM` or `BED_HEIGHT_MM`. It must preserve native
+bar versus canonical Pa, native g/s or mL/s versus canonical SI, and density
+and conversion provenance. A processed value never replaces its raw parent.
+Evidence partition, analysis role, calibration links, quality flags, inclusion
+status, exclusion rationale, checksums, and processing lineage are mandatory.
+
+## Timebase, timing, calibration, and latency
+
+All raw channels require native timestamps and a declared monotonic canonical
+elapsed-time basis. The physical `t=0` event remains
+`T0_EVENT_SELECTION_PILOT_REQUIRED`; retain every plausible raw marker,
+including command onset, upstream-pressure onset, basket-pressure onset,
+first detected outlet liquid, collection start, and instrument triggers.
+
+The following are separate records and must not be collapsed:
+
+- native sample interval, with the model-informed objective `<= 20 ms` where
+  the channel can support it;
+- useful measurement bandwidth, `SENSOR_SELECTION_REQUIRED` and
+  `PILOT_REQUIRED`;
+- inter-channel synchronization error, with model-informed objective
+  `<= 20 ms`;
+- sensor dynamic latency, characterized separately for each channel, with
+  model-informed objective `<= 20 ms` where applicable;
+- physical-`t=0` uncertainty, with model-informed objective `<= 20 ms` after
+  pilot selection;
+- processed resampling interval, prospectively selected and never used to
+  imply native bandwidth, with model-informed objective `<= 20 ms` where
+  justified.
+
+Each approximately 20 ms objective is independently labeled
+`MODEL_INFORMED_FUTURE_DESIGN_TARGET_NOT_VALIDATION_THRESHOLD`. If a single
+hardware clock is unavailable, retain native timestamps and characterize
+offset and drift without overwriting raw data. Pre- and post-session
+calibration records, traceability, range, detection limit, hysteresis, drift,
+zeroing, cross-talk, dynamic response, alignment, and latency must be retained.
+Final sensor models and calibration procedures remain
+`SENSOR_SELECTION_REQUIRED`.
+
+## Deformation spatial and compliance basis
+
+Acquire deformation or bed-height observations at inlet/upper-bed,
+center/mid-bed, and outlet/lower-bed locations. A bulk-equivalent measurement
+may replace those locations only when its spatial weighting and equivalence
+are prospectively justified before acquisition. Record reference state,
+location/coordinates, compression sign, alignment, and unloaded and loaded
+bases. Independently characterize basket, optical window, fixture, sensor
+mount, and reference-frame compliance; apparatus displacement must not be
+reported as coffee-bed deformation. Feasibility remains
+`APPARATUS_FEASIBILITY_REQUIRED`.
 
 ## Uncertainty-budget headings
 
@@ -198,6 +326,13 @@ and citation metadata. Rights must permit the intended independent comparison.
 ## Commissioning-readiness checklist
 
 - [ ] Human owner issues separate commissioning authority.
+- [ ] Future evidence route selected prospectively.
+- [ ] Parameter/evidence-role ledger frozen.
+- [ ] Prescribed-pressure node and control protocol frozen.
+- [ ] Submission data schemas accepted.
+- [ ] Timing definitions and physical `t=0` basis accepted.
+- [ ] Deformation spatial/compliance basis accepted.
+- [ ] Leakage and access controls accepted if a sealed holdout route is used.
 - [ ] Machine-mode campaign gap receives a documented human disposition.
 - [ ] Apparatus and node feasibility: `APPARATUS_FEASIBILITY_REQUIRED`.
 - [ ] Sensors and calibration chain: `SENSOR_SELECTION_REQUIRED`.

--- a/docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md
+++ b/docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md
@@ -198,15 +198,16 @@ Numeric zero is never a missing-value code.
 | `val_data_001_controls.csv` | (`shot_id`, `control_sample_index`) | `shot_id`, `control_sample_index`, `command_program_resource_id`, `clock_resource_id`, `source_file_id`, `value_processing_id`, `raw_or_processed`, `native_timestamp`, `elapsed_time_s`, `commanded_pressure_value`, `commanded_pressure_unit`, `prescribed_node`, `basket_pressure_signal_id`, `basket_pressure_sample_index`, `upstream_pressure_signal_id`, `upstream_pressure_sample_index`, `upstream_pressure_availability`, `control_deviation_pa`, `control_status`, `control_phase` |
 | `val_data_001_flow_conversions.csv` | `conversion_id` | `conversion_id`, `shot_id`, `density_source_resource_id`, `calibration_id`, `calibration_applicability`, `source_file_id`, `native_mass_flow_g_s`, `native_volume_flow_ml_s`, `canonical_mass_flow_kg_s`, `canonical_volume_flow_m3_s`, `density_kg_m3`, `density_temperature_c`, `conversion_formula`, `value_processing_id` |
 | `val_data_001_deformation.csv` | (`shot_id`, `location_id`, `sample_index`) | `shot_id`, `apparatus_id`, `signal_id`, `location_id`, `sample_index`, `sensor_resource_id`, `clock_resource_id`, `calibration_id`, `reference_state_resource_id`, `fixture_compliance_resource_id`, `source_file_id`, `value_processing_id`, `raw_or_processed`, `native_timestamp`, `elapsed_time_s`, `native_displacement_value`, `native_displacement_unit`, `canonical_displacement_m`, `compression_sign`, `spatial_basis`, `axial_coordinate_m`, `radial_coordinate_m`, `coffee_bed_displacement_m`, `quality_flags`, `missing_value_state` |
-| `val_data_001_fractions.csv` | (`shot_id`, `fraction_id`) | `shot_id`, `fraction_id`, `evidence_partition_id`, `fraction_start_s`, `fraction_end_s`, `fraction_mass_g`, `fraction_tds_pct`, `raw_or_processed`, `source_file_id`, `value_processing_id`, `fraction_state` |
+| `val_data_001_fractions.csv` | (`shot_id`, `fraction_id`) | `shot_id`, `fraction_id`, `evidence_partition_id`, `fraction_start_s`, `fraction_end_s`, `fraction_mass_g`, `fraction_tds_pct`, `raw_or_processed`, `source_file_id`, `value_processing_id` |
 | `val_data_001_chemistry.csv` | (`shot_id`, `fraction_id`, `species`) | `shot_id`, `fraction_id`, `evidence_partition_id`, `species`, `mass_mg`, `reference_basis`, `analytical_method_resource_id`, `detection_limit_mg`, `recovery_pct`, `measurement_status`, `source_file_id`, `value_processing_id` |
-| `val_data_001_calibrations.csv` | `calibration_id` | `calibration_id`, `calibration_set_id`, `apparatus_id`, `sensor_resource_id`, `source_file_id`, `observable_code`, `native_unit`, `canonical_unit`, `calibration_method`, `reference_resource_id`, `calibration_timestamp_utc`, `offset`, `scale`, `range_min`, `range_max`, `resolution`, `bandwidth_hz`, `latency_s`, `drift_per_s`, `uncertainty_resource_id`, `valid_from_utc`, `valid_to_utc` |
+| `val_data_001_calibrations.csv` | `calibration_id` | `calibration_id`, `campaign_instance_id`, `evidence_partition_id`, `calibration_set_id`, `apparatus_id`, `sensor_resource_id`, `source_file_id`, `observable_code`, `native_unit`, `canonical_unit`, `calibration_method`, `reference_resource_id`, `calibration_timestamp_utc`, `offset`, `scale`, `range_min`, `range_max`, `resolution`, `bandwidth_hz`, `latency_s`, `drift_per_s`, `uncertainty_resource_id`, `valid_from_utc`, `valid_to_utc` |
 | `val_data_001_files.csv` | `source_file_id` | `source_file_id`, `relative_filename`, `file_role`, `raw_or_processed`, `sha256`, `byte_count`, `media_type`, `rights_resource_id`, `creator_software_resource_id`, `campaign_instance_id`, `evidence_partition_id` |
 | `val_data_001_processing_operations.csv` | `processing_id` | `processing_id`, `operation_scope`, `software_commit`, `software_tree`, `operation_resource_id`, `parameter_record_json_canonical`, `synchronization_method`, `resampling_method`, `operator_role_resource_id`, `processing_timestamp_utc` |
 | `val_data_001_processing_file_edges.csv` | (`processing_id`, `edge_role`, `source_file_id`) | `processing_id`, `edge_role`, `source_file_id`, `edge_sequence`, `channel_or_output_role` |
-| `val_data_001_compatibility_packages.csv` | `compatibility_package_id` | `compatibility_package_id`, `campaign_instance_id`, `route_id`, `evidence_partition_id`, `puckworks_campaign_id`, `access_policy_resource_id`, `rights_resource_id`, `package_access_status`, `package_evidence_class`, `package_manifest_sha256`, `assembly_processing_id`, `export_status` |
+| `val_data_001_compatibility_packages.csv` | `compatibility_package_id` | `compatibility_package_id`, `campaign_instance_id`, `route_id`, `evidence_partition_id`, `puckworks_campaign_id`, `access_policy_resource_id`, `rights_resource_id`, `package_access_status`, `package_evidence_class`, `package_dataset_status`, `package_evidence_level_claimed`, `replicate_count`, `excluded_shot_count`, `exclusions_recorded`, `fraction_chemistry_status`, `package_manifest_sha256`, `export_grid_id`, `export_processing_id`, `export_status` |
 | `val_data_001_export_grids.csv` | `export_grid_id` | `export_grid_id`, `compatibility_package_id`, `grid_start_s`, `grid_end_s`, `resampling_interval_s`, `alignment_tolerance_s`, `basket_pressure_rule`, `delivered_mass_rule`, `flow_rule`, `temperature_rule`, `missing_value_rule`, `grid_freeze_resource_id` |
-| `val_data_001_export_source_rows.csv` | (`compatibility_package_id`, `export_filename`, `export_row_key`, `export_field`) | `compatibility_package_id`, `export_filename`, `export_row_key`, `export_field`, `source_table`, `source_key_json_canonical`, `conversion_id`, `value_processing_id`, `export_processing_id` |
+| `val_data_001_export_source_rows.csv` | (`compatibility_package_id`, `export_filename`, `export_row_key`, `export_field`) | `compatibility_package_id`, `export_filename`, `export_row_key`, `export_field`, `exported_row_state`, `source_mode`, `source_count`, `interpolation_formula`, `conversion_id`, `export_processing_id`, `missing_value_state` |
+| `val_data_001_export_source_samples.csv` | (`compatibility_package_id`, `export_filename`, `export_row_key`, `export_field`, `source_ordinal`) | `compatibility_package_id`, `export_filename`, `export_row_key`, `export_field`, `source_ordinal`, `source_table`, `source_key_json_canonical`, `source_elapsed_time_s`, `source_raw_or_processed`, `source_value_processing_id`, `interpolation_weight_decimal` |
 
 The locked Puckworks bindings distinguish immutable schemas from future data.
 `campaign_instance_id` is the authoritative local identifier for one
@@ -317,6 +318,35 @@ use the same one-partition-per-package rule, with their route-specific access
 states. This prevents compatibility presentation from becoming an access
 side channel.
 
+Every package identity and summary is derived solely from its one
+`evidence_partition_id`. `package_evidence_class`, access policy, terminal
+rights, sealing-derived access status, dataset status, and claimed evidence
+level equal or are deterministically derived from that partition and its
+route. `puckworks_campaign_id` exactly equals the parent campaign mapping.
+`replicate_count` counts distinct package-partition replicates;
+`excluded_shot_count` counts excluded shots in that partition; and
+`exclusions_recorded` is exactly `excluded_shot_count > 0`. Exported shots,
+fractions, chemistry, calibrations, files, exclusions, and all counts are
+restricted to the same partition. A calibration package cannot query, count,
+summarize, infer status from, or otherwise depend on a sealed-scoring
+partition. Any mismatch blocks package assembly.
+
+The exact package-state mapping is: partition `evidence_class` copies to
+`package_evidence_class`; partition `access_policy_resource_id` and
+`rights_resource_id` copy byte-for-byte to the package; `UNSEALED_CALIBRATION`
+maps to `CALIBRATION_ACCESS`; `SEALED_UNACCESSED` maps to
+`SEALED_UNACCESSED`; `AUTHORIZED_OPENED` maps to `AUTHORIZED_OPENED`;
+`CLOSED_AFTER_SCORING` maps to `CLOSED_AFTER_SCORING`; and
+`NOT_APPLICABLE` maps to `OPEN_AUTHORIZED` only when the partition access
+policy authorizes ordinary access. `PUBLIC_METADATA_ONLY` describes only a
+metadata/checksum presentation and grants no observation access.
+
+`fraction_chemistry_status` is package-level and exactly `PRESENT` or
+`NOT_APPLICABLE_NO_FRACTIONATED_CHEMISTRY`. `PRESENT` requires at least one
+fraction row in the package partition and complete reconciliation of all
+applicable fraction and chemistry exports. The not-applicable state requires
+zero fraction and zero chemistry rows and prohibits fabricated empty rows.
+
 #### Row-value and file-assembly lineage
 
 `operation_scope` is exactly `ROW_VALUE`, `NORMALIZED_FILE_ASSEMBLY`, or
@@ -328,22 +358,49 @@ schema and is not authoritative. All actual dependencies use
 `processing_file_edges`; every processed or derived file has exactly one
 output producer, every producer has at least one input and one output, native
 files have no output producer, and the bipartite file-operation graph is
-acyclic. Compatibility packages reference their single assembly operation,
-and every export source row references its export operation.
+acyclic. Every compatibility package references exactly one
+`export_processing_id`, whose operation scope is `COMPATIBILITY_EXPORT`;
+`NORMALIZED_FILE_ASSEMBLY` is not accepted for package export. Every export
+source row references that same export operation.
 
 #### Exact synchronized-time-series and terminal-mass export
 
-Every `shot_timeseries.csv` package uses one frozen `export_grid_id`. Its grid
+Every package that produces `shot_timeseries.csv` has one required
+`export_grid_id`, and `export_grids.compatibility_package_id` is unique. Thus
+the package and grid reference each other one-to-one; zero or multiple active
+grids fail export readiness. Its grid
 start, end, interval, alignment tolerance, per-observable selection or
 interpolation rule, and missing-value behavior are explicit. Export rows are
 ordered by `(shot_id, elapsed_s)`; each field records a complete canonical
-source key in `val_data_001_export_source_rows.csv`. Exact samples are used
-when present. Otherwise interpolation is allowed only by the frozen rule,
-within tolerance, between two quality-eligible samples; extrapolation is
-prohibited. Missing values remain empty with an explicit quality disposition.
+source set through `val_data_001_export_source_rows.csv` and its child
+`val_data_001_export_source_samples.csv`. `source_mode=EXACT_SAMPLE` requires
+`source_count=1`, ordinal 1, weight exactly 1, and the complete source primary
+key. `source_mode=LINEAR_INTERPOLATION` requires exactly two samples ordered
+by time and then source key, ordinals 1 and 2, both complete primary keys, the
+frozen formula, and explicit finite weights summing exactly to 1. Otherwise
+interpolation is allowed only by the frozen rule, within tolerance, between
+two quality-eligible samples; extrapolation is prohibited. Missing values use
+`source_mode=MISSING`, `source_count=0`, no child rows, an empty exported value,
+and an explicit missing state.
+
+`exported_row_state` is frozen for the complete output row. An output row may
+use exact and interpolated values only from compatible
+`PROCESSED_SYNCHRONIZED` or `DERIVED` states declared by the export contract;
+raw-native and synchronized values are never silently combined. Every child
+retains its source `raw_or_processed` state and value-processing identity.
+`conversion_id` is non-null and resolves whenever flow, density, mass/volume,
+or unit conversion participates; it is null only when no conversion is used.
 Pressure is the basket-top Pa-gauge value divided by exactly 100000; upstream
 pressure is not substituted. Conversions and processing identities are
 retained.
+
+Temperature is represented as a registered signal with observable/node code
+`T_MACHINE_UPSTREAM_RU_C` or `T_BASKET_BED_TOP_C`, canonical unit `degC`, and
+the same apparatus, sensor, clock, calibration, quality, and source rules as
+other signals. `shot_timeseries.csv.temperature_c` uses only
+`T_BASKET_BED_TOP_C`; the upstream temperature is retained separately and is
+not substituted. An absent basket-top temperature exports an empty value with
+the frozen missing state.
 
 `achieved_beverage_g` uses the last quality-eligible `DELIVERED_MASS_G` sample
 at or before the prospectively frozen termination event. Ties resolve by the
@@ -367,13 +424,13 @@ commissioning readiness. Export is prohibited unless
 | `campaign_metadata.yml.campaign_id` | `campaigns.puckworks_campaign_id` |
 | `.site_id` | `campaigns.site_id` |
 | `.contributor` | typed canonical payload for `campaigns.contributor_resource_id` |
-| `.dataset_status` | `proposal_only` before acquisition; otherwise `pilot_collected` for pilot-only partitions, `holdout_reserved` for unopened Route-B scoring partitions, and `controlled_dataset` for other controlled acquired partitions |
-| `.evidence_level_claimed` | `feasibility_pilot` for pilot evidence; `controlled_replicated` for controlled comparison/calibration; `holdout_independent` only for an authorized opened Route-B score; no upgrade is implied |
+| `.dataset_status` | `compatibility_packages.package_dataset_status`, derived only from the package partition: `proposal_only` before acquisition; `pilot_collected` for pilot-only partitions; `holdout_reserved` for unopened Route-B scoring partitions; `controlled_dataset` for other controlled acquired partitions |
+| `.evidence_level_claimed` | `compatibility_packages.package_evidence_level_claimed`, derived only from its partition: `feasibility_pilot` for pilot evidence; `controlled_replicated` for controlled comparison/calibration; `holdout_independent` only for an authorized opened Route-B score; no upgrade is implied |
 | `.external_repository`, `.doi` | exact `external_repository` and `doi` members of the `EXTERNAL_REPOSITORY` resource referenced by `campaigns.external_repository_resource_id` |
 | `.data_license` | exact `license` member of the `RIGHTS` resource referenced through the selected route and partitions |
 | `.timezone` | `campaigns.timezone` |
-| `.replicate_count` | count of distinct `replicates.replicate_id` for `campaign_instance_id` |
-| `.exclusions_recorded` | boolean existence of excluded shots for the instance, reconciled with exported `exclusions.csv` |
+| `.replicate_count` | `compatibility_packages.replicate_count`, the count of distinct replicates represented in that package's one evidence partition |
+| `.exclusions_recorded` | `compatibility_packages.exclusions_recorded`, exactly whether `excluded_shot_count > 0` within that package partition and reconciled with its exported `exclusions.csv` |
 | `.deviations_from_protocol` | typed canonical payload for `campaigns.deviations_resource_id` |
 | `.declaration.*` | literal `true` only after the corresponding rights and no-upgrade assertions are verified; otherwise export is prohibited |
 
@@ -411,7 +468,7 @@ commissioning readiness. Export is prohibited unless
 | `beverage_mass_g` | `DELIVERED_MASS_G` authoritative canonical observation converted to g if needed |
 | `flow_g_s` | authoritative mass-flow signal, or authoritative volume flow converted by the referenced flow-conversion/density record |
 | `flow_source` | signal/conversion/source-file/processing identifiers serialized deterministically |
-| `temperature_c` | authoritative temperature signal converted to degrees Celsius |
+| `temperature_c` | authoritative registered `T_BASKET_BED_TOP_C` signal in `degC`; machine-upstream temperature is never substituted |
 | `raw_or_processed` | authoritative exported signal row state |
 
 Separate upstream pressure remains only in the normalized extension because
@@ -438,22 +495,23 @@ the locked `shot_timeseries.csv` has no upstream-pressure column.
 | conditions | (`condition_id`); candidate (`condition_id`, `campaign_instance_id`, `apparatus_id`) |
 | blocks | (`block_id`); candidate (`block_id`, `campaign_instance_id`) |
 | replicates | (`replicate_id`); candidate (`replicate_id`, `campaign_instance_id`, `route_id`, `condition_id`, `block_id`, `evidence_partition_id`) |
-| shots | (`shot_id`); candidate (`shot_id`, `campaign_instance_id`, `route_id`, `condition_id`, `apparatus_id`, `replicate_id`, `block_id`, `evidence_partition_id`) |
+| shots | (`shot_id`); candidate (`shot_id`, `apparatus_id`); candidate (`shot_id`, `evidence_partition_id`); candidate (`shot_id`, `campaign_instance_id`, `route_id`, `condition_id`, `apparatus_id`, `replicate_id`, `block_id`, `evidence_partition_id`) |
 | resources | (`resource_id`) globally unique |
 | resource type schemas | (`payload_schema_id`); candidate (`payload_schema_id`, `resource_type`) |
 | signals | (`shot_id`, `signal_id`, `sample_index`) |
 | controls | (`shot_id`, `control_sample_index`) |
 | flow conversions | (`conversion_id`) |
 | deformation | (`shot_id`, `location_id`, `sample_index`) |
-| fractions | (`shot_id`, `fraction_id`) |
+| fractions | (`shot_id`, `fraction_id`); candidate (`shot_id`, `fraction_id`, `evidence_partition_id`) |
 | chemistry | (`shot_id`, `fraction_id`, `species`) |
 | calibrations | (`calibration_id`) |
 | files | (`source_file_id`) |
 | processing operations | (`processing_id`) |
 | processing file edges | (`processing_id`, `edge_role`, `source_file_id`) |
 | compatibility packages | (`compatibility_package_id`); candidate (`compatibility_package_id`, `campaign_instance_id`, `route_id`, `evidence_partition_id`) |
-| export grids | (`export_grid_id`); candidate (`export_grid_id`, `compatibility_package_id`) |
+| export grids | (`export_grid_id`); unique candidate (`compatibility_package_id`); candidate (`export_grid_id`, `compatibility_package_id`) |
 | export source rows | (`compatibility_package_id`, `export_filename`, `export_row_key`, `export_field`) |
+| export source samples | (`compatibility_package_id`, `export_filename`, `export_row_key`, `export_field`, `source_ordinal`) |
 
 ### Foreign-key resolution matrix
 
@@ -481,8 +539,10 @@ exactly one parent; `NULLABLE` states the sole permitted null condition.
 | `controls.source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one, `NOT NULL` |
 | `flow_conversions.source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one, `NOT NULL` |
 | `deformation.source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one, `NOT NULL` |
+| `fractions.source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one, `NOT NULL` |
 | `chemistry.source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one, `NOT NULL` |
 | `calibrations.source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one, `NOT NULL` |
+| `calibrations.(evidence_partition_id, campaign_instance_id)` | `val_data_001_evidence_partitions.csv.(evidence_partition_id, campaign_instance_id)` | many-to-one, both `NOT NULL`; exported only in the matching package partition |
 | `signals.calibration_id`, `deformation.calibration_id` | `val_data_001_calibrations.csv.calibration_id` | governed by the referenced registry row's `calibration_applicability`; `APPLICABLE` requires a validity-covering calibration, `NOT_APPLICABLE` requires null, and `UNKNOWN_PENDING_REVIEW` requires null and blocks readiness |
 | `flow_conversions.calibration_id` | `val_data_001_calibrations.csv.calibration_id` | many-to-one; `NOT NULL` when `flow_conversions.calibration_applicability=APPLICABLE`; null when it is `NOT_APPLICABLE` or `UNKNOWN_PENDING_REVIEW`, with `UNKNOWN_PENDING_REVIEW` blocking readiness |
 | `signals.value_processing_id`, `controls.value_processing_id`, `flow_conversions.value_processing_id`, `deformation.value_processing_id`, `fractions.value_processing_id`, `chemistry.value_processing_id` | `val_data_001_processing_operations.csv.processing_id` | parent must have `operation_scope=ROW_VALUE`; null only for a directly reported raw native value |
@@ -491,12 +551,55 @@ exactly one parent; `NULLABLE` states the sole permitted null condition.
 | `controls.(shot_id, basket_pressure_signal_id, basket_pressure_sample_index)` | `val_data_001_signals.csv.(shot_id, signal_id, sample_index)` | many-to-one, complete reference `NOT NULL` |
 | `controls.(shot_id, upstream_pressure_signal_id, upstream_pressure_sample_index)` | `val_data_001_signals.csv.(shot_id, signal_id, sample_index)` | many-to-one; signal ID and sample index are both present or both absent, and both may be absent only when `controls.upstream_pressure_availability=NOT_MEASURED` |
 | `chemistry.(shot_id, fraction_id)` | `val_data_001_fractions.csv.(shot_id, fraction_id)` | many-to-one, both `NOT NULL`; partition must agree |
+| `fractions.(shot_id, evidence_partition_id)` | `val_data_001_shots.csv.(shot_id, evidence_partition_id)` | many-to-one, both `NOT NULL` |
+| `chemistry.(shot_id, fraction_id, evidence_partition_id)` | `val_data_001_fractions.csv.(shot_id, fraction_id, evidence_partition_id)` | many-to-one, all `NOT NULL`; this also binds the shot partition |
 | `files.(evidence_partition_id, campaign_instance_id)` | `val_data_001_evidence_partitions.csv.(evidence_partition_id, campaign_instance_id)` | many-to-one, both `NOT NULL`; partition route must agree with campaign |
 | `compatibility_packages.(evidence_partition_id, campaign_instance_id, route_id)` | `val_data_001_evidence_partitions.csv.(evidence_partition_id, campaign_instance_id, route_id)` | many-to-one, all `NOT NULL`; one partition per package |
-| `compatibility_packages.assembly_processing_id` | `val_data_001_processing_operations.csv.processing_id` | many-to-one, `NOT NULL`; parent scope is `NORMALIZED_FILE_ASSEMBLY` or `COMPATIBILITY_EXPORT` as applicable |
+| `compatibility_packages.puckworks_campaign_id` | `val_data_001_campaigns.csv.puckworks_campaign_id` through the package `campaign_instance_id` | exact equality; `NOT NULL` for an exportable locked mapping, otherwise package export prohibited |
+| `compatibility_packages.export_processing_id` | `val_data_001_processing_operations.csv.processing_id` | many-to-one, `NOT NULL`; parent scope must be exactly `COMPATIBILITY_EXPORT` |
+| `compatibility_packages.export_grid_id`, `export_grids.(export_grid_id, compatibility_package_id)` | reciprocal package/grid keys | exactly one grid for each package producing `shot_timeseries.csv`; zero or multiple grids fail |
 | `export_grids.compatibility_package_id`, `export_source_rows.compatibility_package_id` | `val_data_001_compatibility_packages.csv.compatibility_package_id` | many-to-one, `NOT NULL` |
-| `export_source_rows.value_processing_id`, `export_source_rows.export_processing_id` | `val_data_001_processing_operations.csv.processing_id` | value ID nullable only for raw source; export ID `NOT NULL` with scope `COMPATIBILITY_EXPORT` |
+| `export_source_rows.export_processing_id` | `val_data_001_processing_operations.csv.processing_id` | `NOT NULL`, equals its package export operation, scope exactly `COMPATIBILITY_EXPORT` |
+| `export_source_rows.conversion_id` | `val_data_001_flow_conversions.csv.conversion_id` | nullable only when no flow, density, mass/volume, or unit conversion participates in the exported value |
+| `export_source_samples.(compatibility_package_id, export_filename, export_row_key, export_field)` | complete `val_data_001_export_source_rows.csv` primary key | many-to-one, all `NOT NULL` |
+| `export_source_samples.source_value_processing_id` | `val_data_001_processing_operations.csv.processing_id` | nullable only for a directly reported raw-native source sample; otherwise parent scope `ROW_VALUE` |
 | `resources.(payload_schema_id, resource_type)` | `val_data_001_resource_type_schemas.csv.(payload_schema_id, resource_type)` | many-to-one, both `NOT NULL` |
+
+`export_source_samples.source_table` is a controlled external-table binding,
+not a free-form name. Its canonical source-key object has exactly the members
+below and no others:
+
+| `source_table` | Exact `source_key_json_canonical` members |
+|---|---|
+| `val_data_001_signals.csv` | `shot_id`, `signal_id`, `sample_index` |
+| `val_data_001_deformation.csv` | `shot_id`, `location_id`, `sample_index` |
+| `val_data_001_flow_conversions.csv` | `conversion_id` |
+| `val_data_001_shots.csv` | `shot_id` |
+| `val_data_001_fractions.csv` | `shot_id`, `fraction_id` |
+| `val_data_001_chemistry.csv` | `shot_id`, `fraction_id`, `species` |
+
+Every key object resolves to exactly one authoritative row in the same package
+partition. `EXACT_SAMPLE` permits one child with ordinal 1 and weight 1.
+`LINEAR_INTERPOLATION` permits two children with ordinals 1 and 2, strictly
+ordered source times bracketing the export time, and the frozen weights.
+Other cardinalities, incomplete keys, duplicate keys, or cross-partition keys
+are invalid.
+
+### Complete field-coverage classification
+
+The commissioning-readiness audit enumerates every required field in every
+exact table above. Key columns are classified in the primary/candidate-key
+table; relational identifiers are classified in the foreign-key matrix;
+`*_resource_id` columns are classified in the resource-reference matrix;
+Puckworks catalog/template fields and `source_table` keys are controlled
+external bindings. The remaining fields are expressly non-relational scalar,
+measurement, status, enumeration, canonical-payload, checksum, timestamp,
+unit, count, formula, quality, or provenance attributes governed by their
+table and controlled-enumeration rules. A field ending in `_id`, `_ids`, or
+`_key` that is not found in one of those five classes is an audit failure.
+The same fail-closed audit rejects a declared reference whose target table,
+candidate key, resource type, cardinality, null rule, or package partition is
+missing or ambiguous.
 
 ### Resource-reference matrix
 
@@ -535,7 +638,7 @@ reference below resolves to one complete parent key. The required parent
 | `shots.basket_resource_id` | `BASKET` |
 | `shots.preparation_protocol_resource_id` | `PREPARATION_PROTOCOL` |
 | `signals.sensor_resource_id`, `deformation.sensor_resource_id`, `calibrations.sensor_resource_id` | `SENSOR` |
-| `signals.clock_resource_id`, `controls.clock_resource_id` | `CLOCK` |
+| `signals.clock_resource_id`, `controls.clock_resource_id`, `deformation.clock_resource_id` | `CLOCK` |
 | `flow_conversions.density_source_resource_id` | `DENSITY_SOURCE` |
 | `deformation.reference_state_resource_id` | `REFERENCE_STATE` |
 | `deformation.fixture_compliance_resource_id` | `FIXTURE_COMPLIANCE` |
@@ -567,7 +670,7 @@ null rights reference.
 | `inclusion_status` | `INCLUDED`; `EXCLUDED_PREDECLARED_RULE`; `FAILED_RETAINED`; `PENDING_QC` |
 | `missing_value_state` | `PRESENT`; `NOT_MEASURED`; `NOT_APPLICABLE`; `BELOW_DETECTION`; `SENSOR_FAILURE`; `MISSING_UNKNOWN` |
 | `sealed_status` | `NOT_APPLICABLE`; `UNSEALED_CALIBRATION`; `SEALED_UNACCESSED`; `AUTHORIZED_OPENED`; `CLOSED_AFTER_SCORING` |
-| `physical_node`/signal code | `P_MACHINE_UPSTREAM_RU_PA_GAUGE`; `P_BASKET_BED_TOP_PA_GAUGE`; `OUTLET_MASS_FLOW_G_S`; `OUTLET_VOLUME_FLOW_ML_S`; `DELIVERED_MASS_G`; `DEFORMATION_UPPER_M`; `DEFORMATION_MID_M`; `DEFORMATION_LOWER_M`; `BED_HEIGHT_BULK_M`; `FIRST_DRIP_EVENT_S` |
+| `physical_node`/signal code | `P_MACHINE_UPSTREAM_RU_PA_GAUGE`; `P_BASKET_BED_TOP_PA_GAUGE`; `T_MACHINE_UPSTREAM_RU_C`; `T_BASKET_BED_TOP_C`; `OUTLET_MASS_FLOW_G_S`; `OUTLET_VOLUME_FLOW_ML_S`; `DELIVERED_MASS_G`; `DEFORMATION_UPPER_M`; `DEFORMATION_MID_M`; `DEFORMATION_LOWER_M`; `BED_HEIGHT_BULK_M`; `FIRST_DRIP_EVENT_S` |
 | `control_status` | `PENDING_FEASIBILITY`; `WITHIN_FROZEN_TOLERANCE`; `OUTSIDE_FROZEN_TOLERANCE`; `CONTROL_FAILURE` |
 | `control_phase` | `PRE_SHOT`; `RAMP`; `PLATEAU`; `TERMINATION`; `POST_SHOT` |
 | `block_type` | `SESSION`; `COFFEE_LOT`; `GRINDER_STATE`; `OPERATOR_STATE`; `APPARATUS_CALIBRATION_STATE` |
@@ -579,9 +682,11 @@ null rights reference.
 | `campaign_mapping_status` | `LOCKED_PUCKWORKS_CAMPAIGN`; `PUCKWORKS_MACHINE_MODE_CAMPAIGN_GAP_LOCAL_EXTENSION`; `FUTURE_PUCKWORKS_CAMPAIGN_PENDING` |
 | `edge_role` | `INPUT`; `OUTPUT` |
 | `operation_scope` | `ROW_VALUE`; `NORMALIZED_FILE_ASSEMBLY`; `COMPATIBILITY_EXPORT` |
-| `fraction_state` | `PRESENT`; `NOT_APPLICABLE_NO_FRACTIONATED_CHEMISTRY` |
-| `package_access_status` | `OPEN_AUTHORIZED`; `CALIBRATION_ACCESS`; `SEALED_UNACCESSED`; `AUTHORIZED_OPENED`; `PUBLIC_METADATA_ONLY` |
+| `package_access_status` | `OPEN_AUTHORIZED`; `CALIBRATION_ACCESS`; `SEALED_UNACCESSED`; `AUTHORIZED_OPENED`; `CLOSED_AFTER_SCORING`; `PUBLIC_METADATA_ONLY` |
 | `export_status` | `NOT_GENERATED`; `GENERATED_VERIFIED`; `PROHIBITED_SEALED`; `NOT_APPLICABLE` |
+| `fraction_chemistry_status` | `PRESENT`; `NOT_APPLICABLE_NO_FRACTIONATED_CHEMISTRY` |
+| `source_mode` | `EXACT_SAMPLE`; `LINEAR_INTERPOLATION`; `MISSING` |
+| `exported_row_state` | `PROCESSED_SYNCHRONIZED`; `DERIVED_WITH_SYNCHRONIZED_SOURCES`; `MISSING_DECLARED` |
 
 ### Route-conditional partition representation
 
@@ -724,6 +829,25 @@ table and invalidate the export.
 14. Every synchronized export row has one frozen grid position and complete
     source-key records. Every achieved-mass value has one exact terminal
     delivered-mass source key selected by the frozen termination rule.
+15. Package campaign, route, partition, Puckworks campaign, evidence class,
+    access policy, terminal rights, access status, dataset status, and evidence
+    level reconcile to one parent partition and campaign. Package counts and
+    exclusion summaries use only rows in that partition.
+16. Package shots, files, calibrations, fractions, chemistry, exclusions,
+    source samples, grids, and processing inputs share the package partition.
+    A Route-B calibration package has no edge, key, count, status, checksum,
+    or derived dependency on a sealed-scoring partition.
+17. A time-series-producing package has exactly one reciprocal package/grid
+    pair and exactly one export operation of scope `COMPATIBILITY_EXPORT`.
+    A normalized-file assembly operation cannot satisfy that reference.
+18. Temperature export resolves only to registered
+    `T_BASKET_BED_TOP_C` samples. Exact exports retain one source; interpolated
+    exports retain two ordered, bracketing sources and frozen weights; missing
+    exports retain no source and an explicit missing state.
+19. `fraction_chemistry_status=PRESENT` is equivalent to a nonempty,
+    reconciled package fraction set. The not-applicable state is equivalent to
+    zero fraction and chemistry rows and emits neither fraction nor chemistry
+    data files.
 
 ## Timebase, timing, calibration, and latency
 

--- a/docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md
+++ b/docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md
@@ -194,6 +194,7 @@ Numeric zero is never a missing-value code.
 | `val_data_001_resource_type_schemas.csv` | `payload_schema_id` | `payload_schema_id`, `resource_type`, `schema_version`, `required_members_json_canonical`, `optional_members_json_canonical`, `member_types_json_canonical`, `additional_members_allowed`, `schema_sha256` |
 | `val_data_001_conditions.csv` | `condition_id` | `condition_id`, `campaign_instance_id`, `apparatus_id`, `control_mode`, `prescribed_node`, `prescribed_pressure_pa_gauge`, `command_program_resource_id`, `initial_hydraulic_state_resource_id`, `ambient_reference_pa`, `zeroing_basis`, `ramp_definition`, `plateau_definition`, `termination_rule`, `control_tolerance_pa`, `missing_value_state` |
 | `val_data_001_shots.csv` | `shot_id` | `shot_id`, `campaign_instance_id`, `route_id`, `condition_id`, `apparatus_id`, `replicate_id`, `block_id`, `evidence_partition_id`, `coffee_lot_resource_id`, `grinder_resource_id`, `basket_resource_id`, `dose_g`, `dry_bed_depth_mm`, `preparation_protocol_resource_id`, `target_beverage_g`, `brew_temperature_c`, `raw_or_processed`, `inclusion_status`, `exclusion_reason`, `t0_event_code`, `t0_uncertainty_s` |
+| `val_data_001_shot_events.csv` | (`shot_id`, `event_id`) | `shot_id`, `event_id`, `event_code`, `elapsed_time_s`, `source_file_id`, `value_processing_id`, `event_status`, `uncertainty_s`, `quality_flags` |
 | `val_data_001_signals.csv` | (`shot_id`, `signal_id`, `sample_index`) | `shot_id`, `apparatus_id`, `signal_id`, `sample_index`, `sensor_resource_id`, `clock_resource_id`, `calibration_id`, `source_file_id`, `value_processing_id`, `native_timestamp`, `elapsed_time_s`, `native_value`, `native_unit`, `canonical_value`, `canonical_unit`, `physical_node`, `raw_or_processed`, `quality_flags`, `missing_value_state`, `clock_offset_s`, `clock_drift_s_per_s`, `sensor_latency_s`, `resampling_interval_s` |
 | `val_data_001_controls.csv` | (`shot_id`, `control_sample_index`) | `shot_id`, `control_sample_index`, `command_program_resource_id`, `clock_resource_id`, `source_file_id`, `value_processing_id`, `raw_or_processed`, `native_timestamp`, `elapsed_time_s`, `commanded_pressure_value`, `commanded_pressure_unit`, `prescribed_node`, `basket_pressure_signal_id`, `basket_pressure_sample_index`, `upstream_pressure_signal_id`, `upstream_pressure_sample_index`, `upstream_pressure_availability`, `control_deviation_pa`, `control_status`, `control_phase` |
 | `val_data_001_flow_conversions.csv` | `conversion_id` | `conversion_id`, `shot_id`, `density_source_resource_id`, `calibration_id`, `calibration_applicability`, `source_file_id`, `native_mass_flow_g_s`, `native_volume_flow_ml_s`, `canonical_mass_flow_kg_s`, `canonical_volume_flow_m3_s`, `density_kg_m3`, `density_temperature_c`, `conversion_formula`, `value_processing_id` |
@@ -204,10 +205,12 @@ Numeric zero is never a missing-value code.
 | `val_data_001_files.csv` | `source_file_id` | `source_file_id`, `relative_filename`, `file_role`, `raw_or_processed`, `sha256`, `byte_count`, `media_type`, `rights_resource_id`, `creator_software_resource_id`, `campaign_instance_id`, `evidence_partition_id` |
 | `val_data_001_processing_operations.csv` | `processing_id` | `processing_id`, `operation_scope`, `software_commit`, `software_tree`, `operation_resource_id`, `parameter_record_json_canonical`, `synchronization_method`, `resampling_method`, `operator_role_resource_id`, `processing_timestamp_utc` |
 | `val_data_001_processing_file_edges.csv` | (`processing_id`, `edge_role`, `source_file_id`) | `processing_id`, `edge_role`, `source_file_id`, `edge_sequence`, `channel_or_output_role` |
-| `val_data_001_compatibility_packages.csv` | `compatibility_package_id` | `compatibility_package_id`, `campaign_instance_id`, `route_id`, `evidence_partition_id`, `puckworks_campaign_id`, `access_policy_resource_id`, `rights_resource_id`, `package_access_status`, `package_evidence_class`, `package_dataset_status`, `package_evidence_level_claimed`, `replicate_count`, `excluded_shot_count`, `exclusions_recorded`, `fraction_chemistry_status`, `package_manifest_sha256`, `export_grid_id`, `export_processing_id`, `export_status` |
+| `val_data_001_compatibility_packages.csv` | `compatibility_package_id` | `compatibility_package_id`, `campaign_instance_id`, `route_id`, `evidence_partition_id`, `puckworks_campaign_id`, `access_policy_resource_id`, `rights_resource_id`, `package_access_status`, `package_evidence_class`, `package_dataset_status`, `package_evidence_level_claimed`, `replicate_count`, `excluded_shot_count`, `exclusions_recorded`, `fraction_chemistry_status`, `package_content_mode`, `package_manifest_sha256`, `export_grid_id`, `export_processing_id`, `export_status` |
 | `val_data_001_export_grids.csv` | `export_grid_id` | `export_grid_id`, `compatibility_package_id`, `grid_start_s`, `grid_end_s`, `resampling_interval_s`, `alignment_tolerance_s`, `basket_pressure_rule`, `delivered_mass_rule`, `flow_rule`, `temperature_rule`, `missing_value_rule`, `grid_freeze_resource_id` |
-| `val_data_001_export_source_rows.csv` | (`compatibility_package_id`, `export_filename`, `export_row_key`, `export_field`) | `compatibility_package_id`, `export_filename`, `export_row_key`, `export_field`, `exported_row_state`, `source_mode`, `source_count`, `interpolation_formula`, `conversion_id`, `export_processing_id`, `missing_value_state` |
+| `val_data_001_export_source_rows.csv` | (`compatibility_package_id`, `export_filename`, `export_row_key`, `export_field`) | `compatibility_package_id`, `export_filename`, `export_row_key`, `export_field`, `exported_row_state`, `provenance_class`, `time_source_mode`, `source_count`, `interpolation_formula`, `flow_conversion_id`, `unit_conversion_mode`, `unit_scale_decimal`, `unit_offset_decimal`, `literal_rule_id`, `export_processing_id`, `missing_value_state` |
+| `val_data_001_export_source_records.csv` | (`compatibility_package_id`, `export_filename`, `export_row_key`, `export_field`, `source_ordinal`) | `compatibility_package_id`, `export_filename`, `export_row_key`, `export_field`, `source_ordinal`, `source_table`, `source_key_json_canonical`, `source_member`, `source_value_processing_id` |
 | `val_data_001_export_source_samples.csv` | (`compatibility_package_id`, `export_filename`, `export_row_key`, `export_field`, `source_ordinal`) | `compatibility_package_id`, `export_filename`, `export_row_key`, `export_field`, `source_ordinal`, `source_table`, `source_key_json_canonical`, `source_elapsed_time_s`, `source_raw_or_processed`, `source_value_processing_id`, `interpolation_weight_decimal` |
+| `val_data_001_export_literal_rules.csv` | `literal_rule_id` | `literal_rule_id`, `export_filename`, `export_field`, `canonical_value`, `scalar_encoding`, `rule_sha256` |
 
 The locked Puckworks bindings distinguish immutable schemas from future data.
 `campaign_instance_id` is the authoritative local identifier for one
@@ -283,12 +286,16 @@ chemistry rows.
 `resource_type`. Canonical serialization is UTF-8 JSON with lexicographically
 sorted object keys, no insignificant whitespace, JSON `null` only where the
 type schema permits it, finite base-10 numbers, and no duplicate keys.
-Required payload members are: `CONTRIBUTOR{name,role}`;
+Required payload members are: `CONTRIBUTOR{contact,role}`;
 `EXTERNAL_REPOSITORY{repository,doi}`; `RIGHTS{license,access_class,
-redistribution_status}`; `SENSOR{manufacturer,model,serial_or_asset_id}`;
-`CLOCK{clock_id,clock_basis}`; `UNCERTAINTY{status,budget_resource_ids}`;
-machine, grinder, burr, basket, and grinder-setting resources
-`{identity,definition}`; command, preparation, reference, density, and
+redistribution_status}`;
+`SENSOR{display_text,manufacturer,model,serial_or_asset_id}`;
+`CLOCK{display_text,clock_id,clock_basis}`;
+`UNCERTAINTY{display_text,status,budget_resource_ids}`;
+`OFFSET_DRIFT{display_text,definition,status}`;
+`GRINDER{display_text,identity,definition,grinder_setting}`; machine, grinder
+model, burr, basket, and grinder-setting resources
+`{display_text,identity,definition}`; command, preparation, reference, density, and
 operation resources `{method,version,parameters}`; and all remaining
 enumerated types `{definition,status}`. Unresolved real-world values use the
 applicable controlled unresolved disposition, not invented values.
@@ -347,9 +354,35 @@ fraction row in the package partition and complete reconciliation of all
 applicable fraction and chemistry exports. The not-applicable state requires
 zero fraction and zero chemistry rows and prohibits fabricated empty rows.
 
+`package_content_mode` controls package nullability exactly:
+
+| Content mode | Files and observations | `export_processing_id` | `export_grid_id` |
+|---|---|---|---|
+| `FULL_COMPATIBILITY_EXPORT` | Complete partition-authorized compatibility files, including `shot_timeseries.csv` | required; scope exactly `COMPATIBILITY_EXPORT` | required; exactly one reciprocal grid |
+| `METADATA_CHECKSUM_ONLY` | Only rights/access metadata, seal identity, and checksum manifest; no observations or time-series sources | required; scope exactly `COMPATIBILITY_EXPORT` | null |
+| `NOT_GENERATED` | No compatibility files | null | null |
+| `NOT_APPLICABLE` | No compatibility files | null | null |
+
+An unopened sealed partition permits only `METADATA_CHECKSUM_ONLY` or
+`NOT_GENERATED`. `export_status`, manifest identity, file set, operation,
+grid, source rows, and access state must agree with the content mode. The four
+modes have mutually exclusive file sets. Both generated modes require
+`export_status=GENERATED_VERIFIED` and a non-null manifest hash;
+`NOT_GENERATED` requires the same-named status and a null manifest hash;
+`NOT_APPLICABLE` requires the same-named status and a null manifest hash.
+The full-mode file set is exactly `campaign_metadata.yml`, `apparatus.yml`,
+`shot_metadata.csv`, `shot_timeseries.csv`, `calibration.csv`,
+`exclusions.csv`, and `file_manifest.csv`, plus `fraction_metadata.csv` and
+`chemistry_measurements.csv` only when `fraction_chemistry_status=PRESENT`.
+The metadata-only file set is exactly `package_manifest.json`,
+`rights_access.json`, and `seal_identity.json`; these contain no observation,
+count, exclusion, or derived scientific value. The other two modes have an
+empty file set.
+
 #### Row-value and file-assembly lineage
 
-`operation_scope` is exactly `ROW_VALUE`, `NORMALIZED_FILE_ASSEMBLY`, or
+`operation_scope` is exactly one of `ROW_VALUE`,
+`NORMALIZED_FILE_ASSEMBLY`, or
 `COMPATIBILITY_EXPORT`. A row's `value_processing_id` references only a
 `ROW_VALUE` operation and is null only for a directly reported raw native
 value. File assembly and compatibility export operations never masquerade as
@@ -358,10 +391,11 @@ schema and is not authoritative. All actual dependencies use
 `processing_file_edges`; every processed or derived file has exactly one
 output producer, every producer has at least one input and one output, native
 files have no output producer, and the bipartite file-operation graph is
-acyclic. Every compatibility package references exactly one
+acyclic. A generated compatibility package references exactly one
 `export_processing_id`, whose operation scope is `COMPATIBILITY_EXPORT`;
-`NORMALIZED_FILE_ASSEMBLY` is not accepted for package export. Every export
-source row references that same export operation.
+non-generated and not-applicable modes reference none.
+`NORMALIZED_FILE_ASSEMBLY` is never accepted for package export. Every export
+source row references the package's same export operation.
 
 #### Exact synchronized-time-series and terminal-mass export
 
@@ -373,14 +407,16 @@ start, end, interval, alignment tolerance, per-observable selection or
 interpolation rule, and missing-value behavior are explicit. Export rows are
 ordered by `(shot_id, elapsed_s)`; each field records a complete canonical
 source set through `val_data_001_export_source_rows.csv` and its child
-`val_data_001_export_source_samples.csv`. `source_mode=EXACT_SAMPLE` requires
+`val_data_001_export_source_samples.csv`.
+`provenance_class=TIME_INDEXED_SAMPLES` with
+`time_source_mode=EXACT_SAMPLE` requires
 `source_count=1`, ordinal 1, weight exactly 1, and the complete source primary
-key. `source_mode=LINEAR_INTERPOLATION` requires exactly two samples ordered
+key. `time_source_mode=LINEAR_INTERPOLATION` requires exactly two samples ordered
 by time and then source key, ordinals 1 and 2, both complete primary keys, the
 frozen formula, and explicit finite weights summing exactly to 1. Otherwise
 interpolation is allowed only by the frozen rule, within tolerance, between
 two quality-eligible samples; extrapolation is prohibited. Missing values use
-`source_mode=MISSING`, `source_count=0`, no child rows, an empty exported value,
+`time_source_mode=MISSING`, `source_count=0`, no child rows, an empty exported value,
 and an explicit missing state.
 
 `exported_row_state` is frozen for the complete output row. An output row may
@@ -388,8 +424,11 @@ use exact and interpolated values only from compatible
 `PROCESSED_SYNCHRONIZED` or `DERIVED` states declared by the export contract;
 raw-native and synchronized values are never silently combined. Every child
 retains its source `raw_or_processed` state and value-processing identity.
-`conversion_id` is non-null and resolves whenever flow, density, mass/volume,
-or unit conversion participates; it is null only when no conversion is used.
+`flow_conversion_id` is non-null only when flow/density or mass-flow/
+volume-flow conversion participates. Fixed scale/offset conversions use no
+flow row. `unit_conversion_mode` is `NONE`, `FIXED_SCALE_OFFSET`, or
+`FLOW_DENSITY_CONVERSION`; exact decimal scale and offset are always retained.
+Pressure conversion can never reference a flow conversion.
 Pressure is the basket-top Pa-gauge value divided by exactly 100000; upstream
 pressure is not substituted. Conversions and processing identities are
 retained.
@@ -402,12 +441,124 @@ other signals. `shot_timeseries.csv.temperature_c` uses only
 not substituted. An absent basket-top temperature exports an empty value with
 the frozen missing state.
 
-`achieved_beverage_g` uses the last quality-eligible `DELIVERED_MASS_G` sample
-at or before the prospectively frozen termination event. Ties resolve by the
-largest `sample_index`. The exact signal primary key and conversion are
-retained. If the termination event or eligible mass sample is absent, the
-value is empty and the shot receives a deterministic exclusion or QC status;
-target mass or a later sample is never substituted.
+Each shot has exactly one realized termination row in
+`val_data_001_shot_events.csv` whose `event_code` equals the prospectively
+selected condition termination event. The row retains realized elapsed time,
+source file, derivation operation when derived, status, uncertainty, and
+quality flags. `achieved_beverage_g` uses the last quality-eligible
+`DELIVERED_MASS_G` sample at or before that exact realized event time. Ties
+resolve by the largest `sample_index`. The event primary key, exact signal
+primary key, and conversion provenance are retained. A condition-level rule
+alone is insufficient. If the realized event or eligible mass sample is
+absent, the value is empty and the shot receives a deterministic exclusion or
+QC status; target mass or a later sample is never substituted.
+
+#### Non-time-indexed export provenance
+
+Every emitted compatibility field has exactly one `provenance_class`:
+`NORMALIZED_RECORD`, `TIME_INDEXED_SAMPLES`, or `FROZEN_LITERAL`.
+`NORMALIZED_RECORD` requires one or more ordered
+`val_data_001_export_source_records.csv` children with complete authoritative
+row keys and exact source members; time, weight, and sample-state fields are
+not present and must not be invented. `TIME_INDEXED_SAMPLES` uses only the
+sample-child table and the exact/interpolated/missing cardinalities above.
+`FROZEN_LITERAL` has no record or sample children and requires one registered
+`literal_rule_id`. Mixed provenance classes for one output field are invalid.
+
+| Compatibility file | Authoritative table | Exact source key |
+|---|---|---|
+| `campaign_metadata.yml` | `val_data_001_campaigns.csv`; package summaries | `campaign_instance_id`; `compatibility_package_id` |
+| `apparatus.yml` | `val_data_001_apparatus.csv`; `val_data_001_apparatus_signals.csv` | `apparatus_id`; (`apparatus_id`, `signal_id`) |
+| `shot_metadata.csv` | `val_data_001_shots.csv`; terminal signal/event sources where applicable | `shot_id`; exact signal/event keys |
+| `calibration.csv` | `val_data_001_calibrations.csv` | `calibration_id` |
+| `exclusions.csv` | `val_data_001_shots.csv` | `shot_id` |
+| `file_manifest.csv` | `val_data_001_files.csv` | `source_file_id` |
+| `fraction_metadata.csv` | `val_data_001_fractions.csv` | (`shot_id`, `fraction_id`) |
+| `chemistry_measurements.csv` | `val_data_001_chemistry.csv` | (`shot_id`, `fraction_id`, `species`) |
+
+For record children, the remaining allowed authoritative table/key pairs are
+`val_data_001_compatibility_packages.csv(compatibility_package_id)`,
+`val_data_001_resources.csv(resource_id)`,
+`val_data_001_shot_events.csv(shot_id,event_id)`,
+`val_data_001_flow_conversions.csv(conversion_id)`, and
+`val_data_001_processing_operations.csv(processing_id)`. No other
+`source_table` value is permitted without prospective contract amendment.
+
+`shot_timeseries.csv` uses time-indexed sources except literal or exact
+record-derived presentation fields. A record child may carry
+`source_value_processing_id` only for a derived normalized scalar; it never
+carries elapsed time, interpolation weight, or source-sample state.
+`exported_row_state` is required for every `shot_timeseries.csv` field and is
+null for every non-time compatibility filename.
+
+Every `export_row_key` is compact canonical JSON with exactly these members:
+
+| Compatibility filename | Exact row-key members |
+|---|---|
+| `campaign_metadata.yml` | `campaign_instance_id` |
+| `apparatus.yml` | `apparatus_id` |
+| `shot_metadata.csv` | `shot_id` |
+| `shot_timeseries.csv` | `shot_id`, `elapsed_s_decimal` |
+| `calibration.csv` | `calibration_id` |
+| `exclusions.csv` | `shot_id` |
+| `file_manifest.csv` | `source_file_id` |
+| `fraction_metadata.csv` | `shot_id`, `fraction_id` |
+| `chemistry_measurements.csv` | `shot_id`, `fraction_id`, `species` |
+
+`elapsed_s_decimal` uses the frozen shortest round-tripping decimal encoding.
+Within a package, every compatibility filename is unique. Within a partition,
+every normalized `relative_filename` is unique. All fields sharing one
+time-series `export_row_key` have exactly the same `exported_row_state`; a
+state mismatch rejects the entire row.
+
+#### Exact scalar compatibility encoding
+
+Simple text YAML scalars are UTF-8 double-quoted YAML 1.2 strings using JSON
+string escaping. CSV follows RFC 4180 with UTF-8, LF records, the literal
+locked header, decimal point `.`, no thousands separators, and empty unquoted
+fields only for declared missing values. Booleans are lowercase `true` or
+`false`; integer counts are unsigned base-10 without leading zeros; finite
+decimal quantities use the shortest round-tripping base-10 form. Compound
+scalars are compact canonical JSON with lexicographically sorted keys, no
+insignificant whitespace or duplicate keys, and the exact resource
+`payload_schema_id`; the JSON string is then CSV-escaped under RFC 4180.
+
+The exact scalar sources are:
+
+- `campaign_metadata.contributor` = `CONTRIBUTOR.contact`;
+- apparatus make/model, burr, wear, and basket fields = `display_text` from
+  their correspondingly typed payloads;
+- signal instrument = `SENSOR.display_text`; uncertainty =
+  `UNCERTAINTY.display_text`; clock = `CLOCK.display_text`; drift =
+  `OFFSET_DRIFT.display_text`;
+- `shot_metadata.grinder_setting` = `GRINDER.grinder_setting`;
+- `calibration.instrument` = `SENSOR.display_text`;
+- `pressure_source` = canonical JSON with exactly `calibration_id`,
+  `signal_id`, `source_file_id`, and `value_processing_id`;
+- `flow_source` = canonical JSON with exactly `flow_conversion_id`,
+  `signal_id`, `source_file_id`, and `value_processing_id`, with JSON null only
+  where the declared conversion domain permits it;
+- calibration notes = canonical JSON with exactly `bandwidth_hz`,
+  `calibration_id`, `drift_per_s`, `latency_s`, `range_max`, `range_min`,
+  `resolution`, `uncertainty_resource_id`, `valid_from_utc`, and
+  `valid_to_utc`;
+- file-manifest notes = canonical JSON with exactly `campaign_instance_id`,
+  `evidence_partition_id`, `producing_processing_id`, and `source_file_id`.
+
+The corresponding schemas require `CONTRIBUTOR.contact`,
+`SENSOR.display_text`, `UNCERTAINTY.display_text`, `CLOCK.display_text`,
+`OFFSET_DRIFT.display_text`, `GRINDER.grinder_setting`, and `display_text` for
+exported apparatus identity/geometry types. An export must not refer to an
+undeclared generic `definition` member.
+
+Fixed compatibility conversions are exact decimals: `Pa gauge -> bar` uses
+scale `0.00001`, offset `0`; `kg -> g` and `kg/s -> g/s` use scale `1000`,
+offset `0`; `m3/s -> mL/s` uses scale `1000000`, offset `0`; `K -> degC` uses
+scale `1`, offset `-273.15`; and a value already in its target unit uses mode
+`NONE`, scale `1`, offset `0`. Flow-density conversion uses mode
+`FLOW_DENSITY_CONVERSION`, an exact `flow_conversion_id`, and the formula
+frozen in that row, with presentation scale `1` and offset `0`. No other conversion is admissible without a prospectively
+amended contract.
 
 ### Deterministic Puckworks compatibility exports
 
@@ -423,7 +574,7 @@ commissioning readiness. Export is prohibited unless
 |---|---|
 | `campaign_metadata.yml.campaign_id` | `campaigns.puckworks_campaign_id` |
 | `.site_id` | `campaigns.site_id` |
-| `.contributor` | typed canonical payload for `campaigns.contributor_resource_id` |
+| `.contributor` | UTF-8 YAML scalar from `CONTRIBUTOR.contact` for `campaigns.contributor_resource_id` |
 | `.dataset_status` | `compatibility_packages.package_dataset_status`, derived only from the package partition: `proposal_only` before acquisition; `pilot_collected` for pilot-only partitions; `holdout_reserved` for unopened Route-B scoring partitions; `controlled_dataset` for other controlled acquired partitions |
 | `.evidence_level_claimed` | `compatibility_packages.package_evidence_level_claimed`, derived only from its partition: `feasibility_pilot` for pilot evidence; `controlled_replicated` for controlled comparison/calibration; `holdout_independent` only for an authorized opened Route-B score; no upgrade is implied |
 | `.external_repository`, `.doi` | exact `external_repository` and `doi` members of the `EXTERNAL_REPOSITORY` resource referenced by `campaigns.external_repository_resource_id` |
@@ -431,22 +582,22 @@ commissioning readiness. Export is prohibited unless
 | `.timezone` | `campaigns.timezone` |
 | `.replicate_count` | `compatibility_packages.replicate_count`, the count of distinct replicates represented in that package's one evidence partition |
 | `.exclusions_recorded` | `compatibility_packages.exclusions_recorded`, exactly whether `excluded_shot_count > 0` within that package partition and reconciled with its exported `exclusions.csv` |
-| `.deviations_from_protocol` | typed canonical payload for `campaigns.deviations_resource_id` |
+| `.deviations_from_protocol` | UTF-8 YAML scalar from `DEVIATION_RECORD.display_text` |
 | `.declaration.*` | literal `true` only after the corresponding rights and no-upgrade assertions are verified; otherwise export is prohibited |
 
 | `apparatus.yml` field | Authoritative normalized source |
 |---|---|
 | `apparatus_id` | `apparatus.apparatus_id` |
-| `machine_make_model`, `grinder_make_model`, `burr_geometry`, `burr_wear_state`, `basket_geometry` | typed canonical payload from the correspondingly named apparatus resource field |
+| `machine_make_model`, `grinder_make_model`, `burr_geometry`, `burr_wear_state`, `basket_geometry` | `display_text` from the correspondingly typed apparatus resource payload |
 | `signals[].observable` | `apparatus_signals.observable_code` |
-| `signals[].instrument` | typed canonical sensor payload for `apparatus_signals.sensor_resource_id` |
+| `signals[].instrument` | `SENSOR.display_text` for `apparatus_signals.sensor_resource_id` |
 | `signals[].native_unit` | `apparatus_signals.native_unit` |
 | `signals[].native_sampling_rate` | reciprocal of `apparatus_signals.native_sample_interval_s`, with the operation and conversion retained |
 | `signals[].calibration` | calibration IDs linked to the signal; `NOT_APPLICABLE` only when `calibration_applicability=NOT_APPLICABLE` |
-| `signals[].uncertainty` | typed canonical payload for `apparatus_signals.uncertainty_resource_id` |
-| `signals[].clock_source` | typed canonical payload for `apparatus_signals.clock_resource_id` |
+| `signals[].uncertainty` | `UNCERTAINTY.display_text` for `apparatus_signals.uncertainty_resource_id` |
+| `signals[].clock_source` | `CLOCK.display_text` for `apparatus_signals.clock_resource_id` |
 | `signals[].synchronization_method` | `apparatus_signals.synchronization_method` |
-| `signals[].offset_drift_estimate` | typed canonical payload for `apparatus_signals.offset_drift_resource_id` |
+| `signals[].offset_drift_estimate` | `OFFSET_DRIFT.display_text` for `apparatus_signals.offset_drift_resource_id` |
 | `signals[].prescribed_or_measured` | `apparatus_signals.prescribed_or_measured` |
 
 | `shot_metadata.csv` field | Authoritative normalized source |
@@ -456,7 +607,7 @@ commissioning readiness. Export is prohibited unless
 | `coffee_lot_id`, `grinder_id`, `basket_id` | exact resource IDs from the shot |
 | `shot_id`, `replicate_id`, `dose_g`, `target_beverage_g`, `brew_temperature_c`, `raw_or_processed`, `exclusion_reason` | same-named authoritative shot fields |
 | `achieved_beverage_g` | authoritative final `DELIVERED_MASS_G` signal sample for the shot |
-| `grinder_setting` | exact `grinder_setting` member of the typed canonical payload for `shots.grinder_resource_id` |
+| `grinder_setting` | exact `GRINDER.grinder_setting` member for `shots.grinder_resource_id` |
 | `included` | `true` only for `inclusion_status=INCLUDED`; otherwise `false` |
 
 | `shot_timeseries.csv` field | Authoritative normalized source/conversion |
@@ -476,9 +627,9 @@ the locked `shot_timeseries.csv` has no upstream-pressure column.
 
 | Remaining locked template | Exact field-level export rule |
 |---|---|
-| `calibration.csv` | `apparatus_id`, `observable`, `unit`, `calibration_datetime_utc`, `calibration_method`, `offset`, and `scale` come from same-named calibration fields (with `observable_code` and `native_unit` name mapping); `instrument` is the sensor resource definition; `notes` deterministically records range, resolution, bandwidth, latency, drift, uncertainty resource, validity interval, and calibration ID |
+| `calibration.csv` | scalar fields come from the calibration row; `instrument=SENSOR.display_text`; `notes` uses the exact canonical-JSON member set defined above |
 | `exclusions.csv` | `campaign_id=campaigns.puckworks_campaign_id`; `shot_id` and `replicate_id` from the shot; `exclusion_reason` from the shot; `recorded_by` from the applicable operator-role resource |
-| `file_manifest.csv` | `filename=files.relative_filename`, `role=files.file_role`, `raw_or_processed`, `sha256`, and `bytes=byte_count`; `license` from the terminal rights resource; `notes` records `source_file_id`, `campaign_instance_id`, and the authoritative producing processing edge, if any |
+| `file_manifest.csv` | scalar fields come from the partition file row; `license=RIGHTS.license`; `notes` uses the exact canonical-JSON member set defined above |
 | `fraction_metadata.csv` | exact locked header; campaign mapping plus authoritative fraction-parent values, or package disposition `NOT_APPLICABLE_NO_FRACTIONATED_CHEMISTRY` |
 | `chemistry_measurements.csv` | when applicable, `campaign_id=campaigns.puckworks_campaign_id`; `shot_id`, `fraction_id`, `species`, `mass_mg`, `reference_basis`, `detection_limit_mg`, `recovery_pct`, and `measurement_status` from chemistry; `analytical_method` from its resource. When no chemistry is acquired, the file is declared `NOT_APPLICABLE` and is not fabricated |
 
@@ -490,12 +641,13 @@ the locked `shot_timeseries.csv` has no upstream-pressure column.
 | sites | (`site_id`) |
 | apparatus | (`apparatus_id`); candidate (`apparatus_id`, `site_id`) |
 | apparatus signals | (`apparatus_id`, `signal_id`) |
-| campaigns | (`campaign_instance_id`); candidate (`campaign_instance_id`, `route_id`); candidate (`campaign_instance_id`, `apparatus_id`) |
+| campaigns | (`campaign_instance_id`); candidate (`campaign_instance_id`, `route_id`); candidate (`campaign_instance_id`, `apparatus_id`); candidate (`campaign_instance_id`, `site_id`, `apparatus_id`) |
 | evidence partitions | (`evidence_partition_id`); candidate (`evidence_partition_id`, `campaign_instance_id`); candidate (`evidence_partition_id`, `campaign_instance_id`, `route_id`) |
 | conditions | (`condition_id`); candidate (`condition_id`, `campaign_instance_id`, `apparatus_id`) |
 | blocks | (`block_id`); candidate (`block_id`, `campaign_instance_id`) |
 | replicates | (`replicate_id`); candidate (`replicate_id`, `campaign_instance_id`, `route_id`, `condition_id`, `block_id`, `evidence_partition_id`) |
 | shots | (`shot_id`); candidate (`shot_id`, `apparatus_id`); candidate (`shot_id`, `evidence_partition_id`); candidate (`shot_id`, `campaign_instance_id`, `route_id`, `condition_id`, `apparatus_id`, `replicate_id`, `block_id`, `evidence_partition_id`) |
+| shot events | (`shot_id`, `event_id`); unique candidate (`shot_id`, `event_code`) for the realized termination code |
 | resources | (`resource_id`) globally unique |
 | resource type schemas | (`payload_schema_id`); candidate (`payload_schema_id`, `resource_type`) |
 | signals | (`shot_id`, `signal_id`, `sample_index`) |
@@ -505,13 +657,15 @@ the locked `shot_timeseries.csv` has no upstream-pressure column.
 | fractions | (`shot_id`, `fraction_id`); candidate (`shot_id`, `fraction_id`, `evidence_partition_id`) |
 | chemistry | (`shot_id`, `fraction_id`, `species`) |
 | calibrations | (`calibration_id`) |
-| files | (`source_file_id`) |
+| files | (`source_file_id`); unique candidate (`evidence_partition_id`, `relative_filename`) |
 | processing operations | (`processing_id`) |
-| processing file edges | (`processing_id`, `edge_role`, `source_file_id`) |
+| processing file edges | (`processing_id`, `edge_role`, `source_file_id`); unique candidate (`processing_id`, `edge_role`, `edge_sequence`) |
 | compatibility packages | (`compatibility_package_id`); candidate (`compatibility_package_id`, `campaign_instance_id`, `route_id`, `evidence_partition_id`) |
 | export grids | (`export_grid_id`); unique candidate (`compatibility_package_id`); candidate (`export_grid_id`, `compatibility_package_id`) |
 | export source rows | (`compatibility_package_id`, `export_filename`, `export_row_key`, `export_field`) |
+| export source records | (`compatibility_package_id`, `export_filename`, `export_row_key`, `export_field`, `source_ordinal`) |
 | export source samples | (`compatibility_package_id`, `export_filename`, `export_row_key`, `export_field`, `source_ordinal`) |
+| export literal rules | (`literal_rule_id`); candidate (`export_filename`, `export_field`, `literal_rule_id`) |
 
 ### Foreign-key resolution matrix
 
@@ -523,6 +677,7 @@ exactly one parent; `NULLABLE` states the sole permitted null condition.
 | `campaigns.puckworks_campaign_id` | locked catalog `docs/data_requests/experimental_campaigns.yml` `$.campaigns[*].campaign_id` | many-to-one; `NOT NULL` only for `campaign_mapping_status=LOCKED_PUCKWORKS_CAMPAIGN`, otherwise null |
 | `campaigns.site_id` | `val_data_001_sites.csv.site_id` | many-to-one, `NOT NULL`; exported to the future template instance |
 | `campaigns.apparatus_id`, `conditions.apparatus_id`, `shots.apparatus_id`, `calibrations.apparatus_id`, `apparatus_signals.apparatus_id` | `val_data_001_apparatus.csv.apparatus_id` | many-to-one, `NOT NULL`; exported to the future template instance |
+| `campaigns.(apparatus_id, site_id)` | `val_data_001_apparatus.csv.(apparatus_id, site_id)` | many-to-one, both `NOT NULL`; separate existence is insufficient |
 | `apparatus.site_id` | `val_data_001_sites.csv.site_id` | many-to-one, `NOT NULL` |
 | `campaigns.route_id`, `evidence_partitions.route_id` | `val_data_001_evidence_routes.csv.route_id` | many-to-one, `NOT NULL` |
 | `evidence_partitions.campaign_instance_id`, `replicates.campaign_instance_id`, `blocks.campaign_instance_id`, `conditions.campaign_instance_id`, `shots.campaign_instance_id`, `files.campaign_instance_id` | `val_data_001_campaigns.csv.campaign_instance_id` | many-to-one, `NOT NULL` |
@@ -532,10 +687,11 @@ exactly one parent; `NULLABLE` states the sole permitted null condition.
 | `replicates.(evidence_partition_id, campaign_instance_id, route_id)` | `val_data_001_evidence_partitions.csv.(evidence_partition_id, campaign_instance_id, route_id)` | many-to-one, all `NOT NULL` |
 | `shots.(replicate_id, campaign_instance_id, route_id, condition_id, block_id, evidence_partition_id)` | corresponding six fields of the replicate candidate key | many-to-one, all `NOT NULL` |
 | `shots.(condition_id, campaign_instance_id, apparatus_id)` | condition candidate key | many-to-one, all `NOT NULL` |
-| `signals.shot_id`, `controls.shot_id`, `flow_conversions.shot_id`, `deformation.shot_id`, `fractions.shot_id`, `chemistry.shot_id` | `val_data_001_shots.csv.shot_id` | many-to-one, `NOT NULL` |
+| `shot_events.shot_id`, `signals.shot_id`, `controls.shot_id`, `flow_conversions.shot_id`, `deformation.shot_id`, `fractions.shot_id`, `chemistry.shot_id` | `val_data_001_shots.csv.shot_id` | many-to-one, `NOT NULL` |
 | `signals.(shot_id, apparatus_id)`, `deformation.(shot_id, apparatus_id)` | `val_data_001_shots.csv.(shot_id, apparatus_id)` | many-to-one, both `NOT NULL` |
 | `signals.(apparatus_id, signal_id)`, `deformation.(apparatus_id, signal_id)` | `val_data_001_apparatus_signals.csv.(apparatus_id, signal_id)` | many-to-one, both `NOT NULL`; registry identity fields must agree |
 | `signals.source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one, `NOT NULL` |
+| `shot_events.source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one, `NOT NULL` |
 | `controls.source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one, `NOT NULL` |
 | `flow_conversions.source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one, `NOT NULL` |
 | `deformation.source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one, `NOT NULL` |
@@ -545,7 +701,7 @@ exactly one parent; `NULLABLE` states the sole permitted null condition.
 | `calibrations.(evidence_partition_id, campaign_instance_id)` | `val_data_001_evidence_partitions.csv.(evidence_partition_id, campaign_instance_id)` | many-to-one, both `NOT NULL`; exported only in the matching package partition |
 | `signals.calibration_id`, `deformation.calibration_id` | `val_data_001_calibrations.csv.calibration_id` | governed by the referenced registry row's `calibration_applicability`; `APPLICABLE` requires a validity-covering calibration, `NOT_APPLICABLE` requires null, and `UNKNOWN_PENDING_REVIEW` requires null and blocks readiness |
 | `flow_conversions.calibration_id` | `val_data_001_calibrations.csv.calibration_id` | many-to-one; `NOT NULL` when `flow_conversions.calibration_applicability=APPLICABLE`; null when it is `NOT_APPLICABLE` or `UNKNOWN_PENDING_REVIEW`, with `UNKNOWN_PENDING_REVIEW` blocking readiness |
-| `signals.value_processing_id`, `controls.value_processing_id`, `flow_conversions.value_processing_id`, `deformation.value_processing_id`, `fractions.value_processing_id`, `chemistry.value_processing_id` | `val_data_001_processing_operations.csv.processing_id` | parent must have `operation_scope=ROW_VALUE`; null only for a directly reported raw native value |
+| `shot_events.value_processing_id`, `signals.value_processing_id`, `controls.value_processing_id`, `flow_conversions.value_processing_id`, `deformation.value_processing_id`, `fractions.value_processing_id`, `chemistry.value_processing_id` | `val_data_001_processing_operations.csv.processing_id` | parent must have `operation_scope=ROW_VALUE`; null only for a directly reported raw native value or event |
 | `processing_file_edges.processing_id` | `val_data_001_processing_operations.csv.processing_id` | many-to-one, `NOT NULL` |
 | `processing_file_edges.source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one, `NOT NULL` |
 | `controls.(shot_id, basket_pressure_signal_id, basket_pressure_sample_index)` | `val_data_001_signals.csv.(shot_id, signal_id, sample_index)` | many-to-one, complete reference `NOT NULL` |
@@ -556,27 +712,25 @@ exactly one parent; `NULLABLE` states the sole permitted null condition.
 | `files.(evidence_partition_id, campaign_instance_id)` | `val_data_001_evidence_partitions.csv.(evidence_partition_id, campaign_instance_id)` | many-to-one, both `NOT NULL`; partition route must agree with campaign |
 | `compatibility_packages.(evidence_partition_id, campaign_instance_id, route_id)` | `val_data_001_evidence_partitions.csv.(evidence_partition_id, campaign_instance_id, route_id)` | many-to-one, all `NOT NULL`; one partition per package |
 | `compatibility_packages.puckworks_campaign_id` | `val_data_001_campaigns.csv.puckworks_campaign_id` through the package `campaign_instance_id` | exact equality; `NOT NULL` for an exportable locked mapping, otherwise package export prohibited |
-| `compatibility_packages.export_processing_id` | `val_data_001_processing_operations.csv.processing_id` | many-to-one, `NOT NULL`; parent scope must be exactly `COMPATIBILITY_EXPORT` |
-| `compatibility_packages.export_grid_id`, `export_grids.(export_grid_id, compatibility_package_id)` | reciprocal package/grid keys | exactly one grid for each package producing `shot_timeseries.csv`; zero or multiple grids fail |
+| `compatibility_packages.export_processing_id` | `val_data_001_processing_operations.csv.processing_id` | required for `FULL_COMPATIBILITY_EXPORT` and `METADATA_CHECKSUM_ONLY`, null for `NOT_GENERATED` and `NOT_APPLICABLE`; non-null parent scope exactly `COMPATIBILITY_EXPORT` |
+| `compatibility_packages.export_grid_id`, `export_grids.(export_grid_id, compatibility_package_id)` | reciprocal package/grid keys | exactly one for `FULL_COMPATIBILITY_EXPORT`; null/no row for all other modes |
 | `export_grids.compatibility_package_id`, `export_source_rows.compatibility_package_id` | `val_data_001_compatibility_packages.csv.compatibility_package_id` | many-to-one, `NOT NULL` |
 | `export_source_rows.export_processing_id` | `val_data_001_processing_operations.csv.processing_id` | `NOT NULL`, equals its package export operation, scope exactly `COMPATIBILITY_EXPORT` |
-| `export_source_rows.conversion_id` | `val_data_001_flow_conversions.csv.conversion_id` | nullable only when no flow, density, mass/volume, or unit conversion participates in the exported value |
-| `export_source_samples.(compatibility_package_id, export_filename, export_row_key, export_field)` | complete `val_data_001_export_source_rows.csv` primary key | many-to-one, all `NOT NULL` |
+| `export_source_rows.flow_conversion_id` | `val_data_001_flow_conversions.csv.conversion_id` | non-null only for `FLOW_DENSITY_CONVERSION`; null for `NONE` and `FIXED_SCALE_OFFSET`; pressure always null |
+| `export_source_rows.literal_rule_id` | `val_data_001_export_literal_rules.csv.literal_rule_id` | non-null only for `FROZEN_LITERAL`; null for record and sample provenance |
+| `export_source_records.(compatibility_package_id, export_filename, export_row_key, export_field)`, `export_source_samples.(compatibility_package_id, export_filename, export_row_key, export_field)` | complete `val_data_001_export_source_rows.csv` primary key | many-to-one, all `NOT NULL`; record and sample child classes are mutually exclusive |
+| `export_source_records.source_value_processing_id` | `val_data_001_processing_operations.csv.processing_id` | nullable for directly reported normalized records; otherwise scope `ROW_VALUE` |
 | `export_source_samples.source_value_processing_id` | `val_data_001_processing_operations.csv.processing_id` | nullable only for a directly reported raw-native source sample; otherwise parent scope `ROW_VALUE` |
 | `resources.(payload_schema_id, resource_type)` | `val_data_001_resource_type_schemas.csv.(payload_schema_id, resource_type)` | many-to-one, both `NOT NULL` |
 
-`export_source_samples.source_table` is a controlled external-table binding,
-not a free-form name. Its canonical source-key object has exactly the members
-below and no others:
+`export_source_samples.source_table` is a controlled time-indexed-table
+binding, not a free-form name. Its canonical source-key object has exactly the
+members below and no others:
 
 | `source_table` | Exact `source_key_json_canonical` members |
 |---|---|
 | `val_data_001_signals.csv` | `shot_id`, `signal_id`, `sample_index` |
 | `val_data_001_deformation.csv` | `shot_id`, `location_id`, `sample_index` |
-| `val_data_001_flow_conversions.csv` | `conversion_id` |
-| `val_data_001_shots.csv` | `shot_id` |
-| `val_data_001_fractions.csv` | `shot_id`, `fraction_id` |
-| `val_data_001_chemistry.csv` | `shot_id`, `fraction_id`, `species` |
 
 Every key object resolves to exactly one authoritative row in the same package
 partition. `EXACT_SAMPLE` permits one child with ordinal 1 and weight 1.
@@ -685,8 +839,12 @@ null rights reference.
 | `package_access_status` | `OPEN_AUTHORIZED`; `CALIBRATION_ACCESS`; `SEALED_UNACCESSED`; `AUTHORIZED_OPENED`; `CLOSED_AFTER_SCORING`; `PUBLIC_METADATA_ONLY` |
 | `export_status` | `NOT_GENERATED`; `GENERATED_VERIFIED`; `PROHIBITED_SEALED`; `NOT_APPLICABLE` |
 | `fraction_chemistry_status` | `PRESENT`; `NOT_APPLICABLE_NO_FRACTIONATED_CHEMISTRY` |
-| `source_mode` | `EXACT_SAMPLE`; `LINEAR_INTERPOLATION`; `MISSING` |
-| `exported_row_state` | `PROCESSED_SYNCHRONIZED`; `DERIVED_WITH_SYNCHRONIZED_SOURCES`; `MISSING_DECLARED` |
+| `package_content_mode` | `FULL_COMPATIBILITY_EXPORT`; `METADATA_CHECKSUM_ONLY`; `NOT_GENERATED`; `NOT_APPLICABLE` |
+| `provenance_class` | `NORMALIZED_RECORD`; `TIME_INDEXED_SAMPLES`; `FROZEN_LITERAL` |
+| `time_source_mode` | `EXACT_SAMPLE`; `LINEAR_INTERPOLATION`; `MISSING`; null for non-time provenance |
+| `unit_conversion_mode` | `NONE`; `FIXED_SCALE_OFFSET`; `FLOW_DENSITY_CONVERSION` |
+| `exported_row_state` | `PROCESSED_SYNCHRONIZED`; `DERIVED_WITH_SYNCHRONIZED_SOURCES`; `MISSING_DECLARED`; null only for non-time compatibility filenames |
+| `event_status` | `OBSERVED`; `DERIVED`; `MISSING`; `AMBIGUOUS_RETAINED` |
 
 ### Route-conditional partition representation
 
@@ -764,16 +922,22 @@ table and invalidate the export.
    acyclic. A deterministic topological sort over files and operations must
    include every node; a cycle or orphan processed file invalidates the
    submission.
-6. Synchronization may consume multiple channel files, and one operation may
-   emit synchronized signals, controls, conversions, and compatibility exports
-   as separate output files without losing shared provenance.
+6. Synchronization is a `ROW_VALUE` operation and may consume multiple native
+   channel files, but it emits only row-value artifacts. A distinct
+   `NORMALIZED_FILE_ASSEMBLY` operation consumes those artifacts and emits
+   complete authoritative normalized tables. A third, distinct
+   `COMPATIBILITY_EXPORT` operation consumes verified normalized tables and
+   emits only Puckworks compatibility files. Edges between layer outputs and
+   subsequent layer inputs preserve shared provenance; one operation never
+   spans layers.
 7. Every compatibility export field above is recomputed from its authoritative
    normalized source during verification. Exported/local disagreement,
    missing input edges, or ambiguous producing operations invalidate the
    export.
-8. `ROW_VALUE` operations may produce normalized value files but never final
-   package assembly. `NORMALIZED_FILE_ASSEMBLY` consumes authoritative row
-   files and produces complete normalized submission files.
+8. `ROW_VALUE` operations produce only raw/intermediate/synchronized row-value
+   artifacts, never complete normalized tables or compatibility files.
+   `NORMALIZED_FILE_ASSEMBLY` consumes row-value artifacts and produces only
+   complete authoritative normalized submission tables.
    `COMPATIBILITY_EXPORT` consumes verified normalized files and produces only
    the partition-specific Puckworks presentation. Scope mixing invalidates the
    graph.
@@ -781,6 +945,10 @@ table and invalidate the export.
    input multiplicity, the unique producer, software identity, parameters,
    and output identity are reconstructed exclusively from operation rows and
    input/output edges.
+10. `(processing_id, edge_role, edge_sequence)` is unique. Within each role,
+    edge sequence starts at 1 and is gap-free; ordering is by that integer,
+    never filesystem enumeration. Each operation declares exactly one scope,
+    and every output file role is permitted by that scope.
 
 ### Cross-table relational invariants
 
@@ -848,6 +1016,24 @@ table and invalidate the export.
     reconciled package fraction set. The not-applicable state is equivalent to
     zero fraction and chemistry rows and emits neither fraction nor chemistry
     data files.
+20. Campaign `(apparatus_id, site_id)` resolves to the apparatus candidate
+    key. Package-relative compatibility filenames and partition-relative
+    normalized filenames are unique. Export row keys match the exact
+    filename-specific schemas, and every field of one time-series row has an
+    identical `exported_row_state`.
+21. A source row uses exactly one provenance class. Non-time record children
+    have no elapsed time, weight, or sample state; time-indexed children have
+    the frozen one- or two-source cardinality; literals have no children.
+22. Fixed unit conversions retain exact scale and offset with null
+    `flow_conversion_id`. Flow-density conversions require that ID. Pressure
+    never references a flow conversion.
+23. Every full package has one grid and one compatibility-export operation;
+    metadata/checksum-only packages have the export operation but no grid;
+    non-generated and not-applicable packages have neither. File sets are
+    mutually exclusive by mode.
+24. Every achieved beverage mass resolves to one realized shot-termination
+    event and one eligible delivered-mass sample selected against its elapsed
+    time. Missing or ambiguous events cannot silently select a mass.
 
 ## Timebase, timing, calibration, and latency
 

--- a/docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md
+++ b/docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md
@@ -17,7 +17,8 @@ The future package should determine whether synchronized pressure, flow/mass,
 and deformation distinguish hydraulic resistance from compaction response;
 whether the existing universal and finite-porosity branches produce resolvable
 differences; which machine-side parameters remain practically confounded; and
-whether an independently held-out dataset can support a bounded component
+whether a prospectively protected comparison dataset under the selected
+evidence route can support a bounded component
 comparison. Results may support parameter/model-form discrimination or show
 that additional data are required. A governing-physics increment would be
 considered only after reproducible, uncertainty-aware residual structure
@@ -184,30 +185,54 @@ Numeric zero is never a missing-value code.
 | `val_data_001_evidence_routes.csv` | `route_id` | `route_id`, `selected_route`, `calibration_evidence_class`, `scoring_evidence_class`, `prospective_freeze_resource_id`, `human_owner_disposition_resource_id`, `rights_policy_resource_id`, `access_policy_resource_id` |
 | `val_data_001_campaigns.csv` | `campaign_id` | `campaign_id`, `puckworks_campaign_id`, `site_id`, `apparatus_id`, `route_id`, `schema_version` |
 | `val_data_001_evidence_partitions.csv` | `evidence_partition_id` | `evidence_partition_id`, `campaign_id`, `route_id`, `analysis_role`, `evidence_class`, `sealed_status`, `partition_manifest_sha256`, `seal_timestamp_utc`, `custodian_resource_id`, `access_policy_resource_id`, `rights_resource_id` |
-| `val_data_001_replicates.csv` | `replicate_id` | `replicate_id`, `campaign_id`, `condition_id`, `block_id`, `replicate_sequence`, `randomization_sequence`, `evidence_partition_id` |
+| `val_data_001_replicates.csv` | `replicate_id` | `replicate_id`, `campaign_id`, `route_id`, `condition_id`, `block_id`, `replicate_sequence`, `randomization_sequence`, `evidence_partition_id` |
 | `val_data_001_blocks.csv` | `block_id` | `block_id`, `campaign_id`, `block_type`, `block_label`, `session_start_utc`, `coffee_lot_resource_id`, `grinder_state_resource_id`, `operator_role_resource_id`, `apparatus_state_resource_id`, `calibration_set_id` |
-| `val_data_001_resources.csv` | (`resource_type`, `resource_id`) | `resource_type`, `resource_id`, `definition`, `source_file_id`, `rights_resource_id` |
+| `val_data_001_resources.csv` | `resource_id` (globally unique) | `resource_id`, `resource_type`, `definition`, `resource_provenance_mode`, `source_file_id`, `rights_resource_id` |
 | `val_data_001_conditions.csv` | `condition_id` | `condition_id`, `campaign_id`, `apparatus_id`, `control_mode`, `prescribed_node`, `prescribed_pressure_pa_gauge`, `command_program_resource_id`, `initial_hydraulic_state_resource_id`, `ambient_reference_pa`, `zeroing_basis`, `ramp_definition`, `plateau_definition`, `termination_rule`, `control_tolerance_pa`, `missing_value_state` |
-| `val_data_001_shots.csv` | `shot_id` | `shot_id`, `campaign_id`, `condition_id`, `apparatus_id`, `replicate_id`, `block_id`, `evidence_partition_id`, `coffee_lot_resource_id`, `grinder_resource_id`, `basket_resource_id`, `dose_g`, `dry_bed_depth_mm`, `preparation_protocol_resource_id`, `brew_temperature_c`, `raw_or_processed`, `inclusion_status`, `exclusion_reason`, `t0_event_code`, `t0_uncertainty_s` |
+| `val_data_001_shots.csv` | `shot_id` | `shot_id`, `campaign_id`, `route_id`, `condition_id`, `apparatus_id`, `replicate_id`, `block_id`, `evidence_partition_id`, `coffee_lot_resource_id`, `grinder_resource_id`, `basket_resource_id`, `dose_g`, `dry_bed_depth_mm`, `preparation_protocol_resource_id`, `brew_temperature_c`, `raw_or_processed`, `inclusion_status`, `exclusion_reason`, `t0_event_code`, `t0_uncertainty_s` |
 | `val_data_001_signals.csv` | (`shot_id`, `signal_id`, `sample_index`) | `shot_id`, `signal_id`, `sample_index`, `sensor_resource_id`, `clock_resource_id`, `calibration_id`, `source_file_id`, `processing_id`, `native_timestamp`, `elapsed_time_s`, `native_value`, `native_unit`, `canonical_value`, `canonical_unit`, `physical_node`, `raw_or_processed`, `quality_flags`, `missing_value_state`, `clock_offset_s`, `clock_drift_s_per_s`, `sensor_latency_s`, `resampling_interval_s` |
-| `val_data_001_controls.csv` | (`shot_id`, `control_sample_index`) | `shot_id`, `control_sample_index`, `command_program_resource_id`, `clock_resource_id`, `source_file_id`, `processing_id`, `native_timestamp`, `elapsed_time_s`, `commanded_pressure_value`, `commanded_pressure_unit`, `prescribed_node`, `basket_pressure_signal_id`, `upstream_pressure_signal_id`, `control_deviation_pa`, `control_status`, `control_phase` |
-| `val_data_001_flow_conversions.csv` | `conversion_id` | `conversion_id`, `shot_id`, `density_source_resource_id`, `calibration_id`, `source_file_id`, `native_mass_flow_g_s`, `native_volume_flow_ml_s`, `canonical_mass_flow_kg_s`, `canonical_volume_flow_m3_s`, `density_kg_m3`, `density_temperature_c`, `conversion_formula`, `processing_id` |
-| `val_data_001_deformation.csv` | (`shot_id`, `location_id`, `sample_index`) | `shot_id`, `location_id`, `sample_index`, `sensor_resource_id`, `calibration_id`, `reference_state_resource_id`, `fixture_compliance_resource_id`, `source_file_id`, `processing_id`, `native_timestamp`, `elapsed_time_s`, `native_displacement_value`, `native_displacement_unit`, `canonical_displacement_m`, `compression_sign`, `spatial_basis`, `axial_coordinate_m`, `radial_coordinate_m`, `coffee_bed_displacement_m`, `quality_flags`, `missing_value_state` |
+| `val_data_001_controls.csv` | (`shot_id`, `control_sample_index`) | `shot_id`, `control_sample_index`, `command_program_resource_id`, `clock_resource_id`, `source_file_id`, `processing_id`, `raw_or_processed`, `native_timestamp`, `elapsed_time_s`, `commanded_pressure_value`, `commanded_pressure_unit`, `prescribed_node`, `basket_pressure_signal_id`, `basket_pressure_sample_index`, `upstream_pressure_signal_id`, `upstream_pressure_sample_index`, `upstream_pressure_availability`, `control_deviation_pa`, `control_status`, `control_phase` |
+| `val_data_001_flow_conversions.csv` | `conversion_id` | `conversion_id`, `shot_id`, `density_source_resource_id`, `calibration_id`, `calibration_applicability`, `source_file_id`, `native_mass_flow_g_s`, `native_volume_flow_ml_s`, `canonical_mass_flow_kg_s`, `canonical_volume_flow_m3_s`, `density_kg_m3`, `density_temperature_c`, `conversion_formula`, `processing_id` |
+| `val_data_001_deformation.csv` | (`shot_id`, `location_id`, `sample_index`) | `shot_id`, `location_id`, `sample_index`, `sensor_resource_id`, `calibration_id`, `reference_state_resource_id`, `fixture_compliance_resource_id`, `source_file_id`, `processing_id`, `raw_or_processed`, `native_timestamp`, `elapsed_time_s`, `native_displacement_value`, `native_displacement_unit`, `canonical_displacement_m`, `compression_sign`, `spatial_basis`, `axial_coordinate_m`, `radial_coordinate_m`, `coffee_bed_displacement_m`, `quality_flags`, `missing_value_state` |
 | `val_data_001_calibrations.csv` | `calibration_id` | `calibration_id`, `calibration_set_id`, `apparatus_id`, `sensor_resource_id`, `source_file_id`, `observable_code`, `native_unit`, `canonical_unit`, `calibration_method`, `reference_resource_id`, `calibration_timestamp_utc`, `offset`, `scale`, `range_min`, `range_max`, `resolution`, `bandwidth_hz`, `latency_s`, `drift_per_s`, `uncertainty_resource_id`, `valid_from_utc`, `valid_to_utc` |
 | `val_data_001_files.csv` | `source_file_id` | `source_file_id`, `parent_source_file_id`, `processing_id`, `relative_filename`, `file_role`, `raw_or_processed`, `sha256`, `byte_count`, `media_type`, `rights_resource_id`, `creator_software_resource_id` |
 | `val_data_001_processing_lineage.csv` | `processing_id` | `processing_id`, `input_source_file_id`, `output_source_file_id`, `software_commit`, `software_tree`, `operation_resource_id`, `parameter_record`, `synchronization_method`, `resampling_method`, `operator_role_resource_id`, `processing_timestamp_utc` |
 
-The locked Puckworks bindings are exact: `campaigns.puckworks_campaign_id`
-references `docs/data_requests/experimental_campaigns.yml` campaign key
-`$.campaigns[*].campaign_id`; `campaigns.site_id` references
-`docs/data_requests/templates/campaign_metadata.yml` key `$.site_id`; and
-`campaigns.apparatus_id`, `conditions.apparatus_id`, and
-`calibrations.apparatus_id` reference
-`docs/data_requests/templates/apparatus.yml` key `$.apparatus_id`, all at the
-locked commit and tree above. The local `campaign_id`, `shot_id`, and
-`replicate_id` values also populate the same-named columns in locked
-`shot_metadata.csv`; this is an equality/export binding, not an additional
-foreign-key parent.
+The locked Puckworks bindings distinguish immutable schemas from future data.
+`campaigns.puckworks_campaign_id` references actual catalog values in locked
+`docs/data_requests/experimental_campaigns.yml` at
+`$.campaigns[*].campaign_id`. By contrast, locked
+`docs/data_requests/templates/campaign_metadata.yml` and
+`docs/data_requests/templates/apparatus.yml` are schemas/templates whose
+repository placeholder values are not parent data. `campaigns.site_id`
+references `$.site_id` in the future submitted `campaign_metadata.yml`
+instance conforming to that locked template. `campaigns.apparatus_id`,
+`conditions.apparatus_id`, `shots.apparatus_id`, and
+`calibrations.apparatus_id` reference `$.apparatus_id` in the future submitted
+`apparatus.yml` instance conforming to its locked template. The local
+`campaign_id`, `shot_id`, and `replicate_id` values also populate the
+same-named columns in a future submitted `shot_metadata.csv` instance; this is
+an equality/export binding, not another foreign-key parent.
+
+### Primary and candidate keys
+
+| Table | Unique key used by references |
+|---|---|
+| evidence routes | (`route_id`) |
+| campaigns | (`campaign_id`); candidate (`campaign_id`, `route_id`); candidate (`campaign_id`, `apparatus_id`) |
+| evidence partitions | (`evidence_partition_id`); candidate (`evidence_partition_id`, `campaign_id`, `route_id`) |
+| conditions | (`condition_id`); candidate (`condition_id`, `campaign_id`, `apparatus_id`) |
+| blocks | (`block_id`); candidate (`block_id`, `campaign_id`) |
+| replicates | (`replicate_id`); candidate (`replicate_id`, `campaign_id`, `route_id`, `condition_id`, `block_id`, `evidence_partition_id`) |
+| shots | (`shot_id`); candidate (`shot_id`, `campaign_id`, `route_id`, `condition_id`, `apparatus_id`, `replicate_id`, `block_id`, `evidence_partition_id`) |
+| resources | (`resource_id`) globally unique |
+| signals | (`shot_id`, `signal_id`, `sample_index`) |
+| controls | (`shot_id`, `control_sample_index`) |
+| flow conversions | (`conversion_id`) |
+| deformation | (`shot_id`, `location_id`, `sample_index`) |
+| calibrations | (`calibration_id`) |
+| files | (`source_file_id`) |
+| processing lineage | (`processing_id`) |
 
 ### Foreign-key resolution matrix
 
@@ -216,25 +241,69 @@ exactly one parent; `NULLABLE` states the sole permitted null condition.
 
 | Child field | Exact parent | Cardinality/null rule |
 |---|---|---|
-| `campaigns.puckworks_campaign_id` | locked `experimental_campaigns.yml` `$.campaigns[*].id` | many-to-one, `NOT NULL` |
-| `campaigns.site_id` | locked `campaign_metadata.yml` `$.site_id` | many-to-one, `NOT NULL` |
-| `campaigns.apparatus_id`, `conditions.apparatus_id`, `calibrations.apparatus_id` | locked `apparatus.yml` `$.apparatus_id` | many-to-one, `NOT NULL` |
+| `campaigns.puckworks_campaign_id` | locked catalog `docs/data_requests/experimental_campaigns.yml` `$.campaigns[*].campaign_id` | many-to-one, `NOT NULL` |
+| `campaigns.site_id` | future submitted `campaign_metadata.yml` `$.site_id`, conforming to locked `docs/data_requests/templates/campaign_metadata.yml` | many-to-one, `NOT NULL`; template placeholder is never a parent value |
+| `campaigns.apparatus_id`, `conditions.apparatus_id`, `shots.apparatus_id`, `calibrations.apparatus_id` | future submitted `apparatus.yml` `$.apparatus_id`, conforming to locked `docs/data_requests/templates/apparatus.yml` | many-to-one, `NOT NULL`; template placeholder is never a parent value |
 | `campaigns.route_id`, `evidence_partitions.route_id` | `val_data_001_evidence_routes.csv.route_id` | many-to-one, `NOT NULL` |
 | `evidence_partitions.campaign_id`, `replicates.campaign_id`, `blocks.campaign_id`, `conditions.campaign_id`, `shots.campaign_id` | `val_data_001_campaigns.csv.campaign_id` | many-to-one, `NOT NULL` |
-| `replicates.condition_id` | `val_data_001_conditions.csv.condition_id` | many-to-one, `NOT NULL` |
-| `replicates.block_id`, `shots.block_id` | `val_data_001_blocks.csv.block_id` | many-to-one, `NOT NULL` |
-| `replicates.evidence_partition_id`, `shots.evidence_partition_id` | `val_data_001_evidence_partitions.csv.evidence_partition_id` | many-to-one, `NOT NULL` |
-| `shots.condition_id` | `val_data_001_conditions.csv.condition_id` | many-to-one, `NOT NULL` |
-| `shots.replicate_id` | `val_data_001_replicates.csv.replicate_id` | one-to-one within a condition, `NOT NULL` |
-| `shots.apparatus_id` | locked `apparatus.yml` `$.apparatus_id` | many-to-one, `NOT NULL` |
+| `evidence_partitions.(campaign_id, route_id)` | `val_data_001_campaigns.csv.(campaign_id, route_id)` | many-to-one, both `NOT NULL` |
+| `replicates.(condition_id, campaign_id)` | `val_data_001_conditions.csv.(condition_id, campaign_id)` | many-to-one, both `NOT NULL` |
+| `replicates.(block_id, campaign_id)` | `val_data_001_blocks.csv.(block_id, campaign_id)` | many-to-one, both `NOT NULL` |
+| `replicates.(evidence_partition_id, campaign_id, route_id)` | `val_data_001_evidence_partitions.csv.(evidence_partition_id, campaign_id, route_id)` | many-to-one, all `NOT NULL` |
+| `shots.(replicate_id, campaign_id, route_id, condition_id, block_id, evidence_partition_id)` | corresponding six fields of the replicate candidate key | many-to-one, all `NOT NULL` |
+| `shots.(condition_id, campaign_id, apparatus_id)` | condition candidate key | many-to-one, all `NOT NULL` |
 | `signals.shot_id`, `controls.shot_id`, `flow_conversions.shot_id`, `deformation.shot_id` | `val_data_001_shots.csv.shot_id` | many-to-one, `NOT NULL` |
-| every field ending `_resource_id` | `val_data_001_resources.csv.resource_id`, paired with the field-implied `resource_type` | many-to-one; `NOT NULL` except `resources.rights_resource_id`, which may be null only for a public-domain resource documented as `PUBLIC_DOMAIN` |
-| `signals.calibration_id`, `flow_conversions.calibration_id`, `deformation.calibration_id` | `val_data_001_calibrations.csv.calibration_id` | many-to-one; null only when `missing_value_state=NOT_APPLICABLE` and the signal definition proves no calibration applies |
-| `calibrations.calibration_set_id`, `blocks.calibration_set_id` | `val_data_001_resources.csv.resource_id` with `resource_type=CALIBRATION_SET` | many-to-one, `NOT NULL` |
 | every `source_file_id`, `input_source_file_id`, `output_source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one, `NOT NULL` |
 | `files.parent_source_file_id` | `val_data_001_files.csv.source_file_id` | many-to-one; null only for an instrument-native root file |
-| every `processing_id` | `val_data_001_processing_lineage.csv.processing_id` | many-to-one; null only when `raw_or_processed=RAW_NATIVE` |
-| `controls.basket_pressure_signal_id`, `controls.upstream_pressure_signal_id` | `val_data_001_signals.csv.signal_id` within the same `shot_id` | many-to-one; basket reference `NOT NULL`; upstream reference null only for prescribed mode when upstream pressure is `NOT_MEASURED` |
+| `signals.calibration_id` | `val_data_001_calibrations.csv.calibration_id` | many-to-one; null only when `signals.missing_value_state=NOT_APPLICABLE` and the signal definition requires no calibration |
+| `flow_conversions.calibration_id` | `val_data_001_calibrations.csv.calibration_id` | many-to-one; `NOT NULL` when `flow_conversions.calibration_applicability=APPLICABLE`; null when it is `NOT_APPLICABLE` or `UNKNOWN_PENDING_REVIEW`, with `UNKNOWN_PENDING_REVIEW` blocking readiness |
+| `deformation.calibration_id` | `val_data_001_calibrations.csv.calibration_id` | many-to-one; null only when `deformation.missing_value_state=NOT_APPLICABLE` and the declared deformation method requires no calibration |
+| `signals.processing_id` | `val_data_001_processing_lineage.csv.processing_id` | many-to-one; null only when `signals.raw_or_processed=RAW_NATIVE` |
+| `controls.processing_id` | `val_data_001_processing_lineage.csv.processing_id` | many-to-one; null only when `controls.raw_or_processed=RAW_NATIVE` and `controls.control_deviation_pa` is empty |
+| `flow_conversions.processing_id` | `val_data_001_processing_lineage.csv.processing_id` | many-to-one, `NOT NULL` |
+| `deformation.processing_id` | `val_data_001_processing_lineage.csv.processing_id` | many-to-one; null only when the deformation row is raw and `coffee_bed_displacement_m` is empty; otherwise `NOT NULL` |
+| `files.processing_id` | `val_data_001_processing_lineage.csv.processing_id` | many-to-one; null only for a declared native/root input file |
+| `controls.(shot_id, basket_pressure_signal_id, basket_pressure_sample_index)` | `val_data_001_signals.csv.(shot_id, signal_id, sample_index)` | many-to-one, complete reference `NOT NULL` |
+| `controls.(shot_id, upstream_pressure_signal_id, upstream_pressure_sample_index)` | `val_data_001_signals.csv.(shot_id, signal_id, sample_index)` | many-to-one; signal ID and sample index are both present or both absent, and both may be absent only when `controls.upstream_pressure_availability=NOT_MEASURED` |
+
+### Resource-reference matrix
+
+`val_data_001_resources.csv.resource_id` is globally unique, so every child
+reference below resolves to one complete parent key. The required parent
+`resource_type` is additionally checked.
+
+| Resource-reference field | Required `resource_type` |
+|---|---|
+| `evidence_routes.prospective_freeze_resource_id` | `FREEZE_IDENTITY` |
+| `evidence_routes.human_owner_disposition_resource_id` | `HUMAN_DISPOSITION` |
+| `evidence_routes.rights_policy_resource_id`, `evidence_partitions.rights_resource_id`, `resources.rights_resource_id`, `files.rights_resource_id` | `RIGHTS` |
+| `evidence_routes.access_policy_resource_id`, `evidence_partitions.access_policy_resource_id` | `ACCESS_POLICY` |
+| `evidence_partitions.custodian_resource_id` | `CUSTODIAN` |
+| `blocks.coffee_lot_resource_id`, `shots.coffee_lot_resource_id` | `COFFEE_LOT` |
+| `blocks.grinder_state_resource_id` | `GRINDER_STATE` |
+| `blocks.operator_role_resource_id`, `processing_lineage.operator_role_resource_id` | `OPERATOR_ROLE` |
+| `blocks.apparatus_state_resource_id` | `APPARATUS_STATE` |
+| `blocks.calibration_set_id`, `calibrations.calibration_set_id` | `CALIBRATION_SET` |
+| `conditions.command_program_resource_id`, `controls.command_program_resource_id` | `COMMAND_PROGRAM` |
+| `conditions.initial_hydraulic_state_resource_id` | `HYDRAULIC_INITIAL_STATE` |
+| `shots.grinder_resource_id` | `GRINDER` |
+| `shots.basket_resource_id` | `BASKET` |
+| `shots.preparation_protocol_resource_id` | `PREPARATION_PROTOCOL` |
+| `signals.sensor_resource_id`, `deformation.sensor_resource_id`, `calibrations.sensor_resource_id` | `SENSOR` |
+| `signals.clock_resource_id`, `controls.clock_resource_id` | `CLOCK` |
+| `flow_conversions.density_source_resource_id` | `DENSITY_SOURCE` |
+| `deformation.reference_state_resource_id` | `REFERENCE_STATE` |
+| `deformation.fixture_compliance_resource_id` | `FIXTURE_COMPLIANCE` |
+| `calibrations.reference_resource_id` | `REFERENCE_STANDARD` |
+| `calibrations.uncertainty_resource_id` | `UNCERTAINTY` |
+| `files.creator_software_resource_id` | `SOFTWARE` |
+| `processing_lineage.operation_resource_id` | `OPERATION` |
+
+`resources.source_file_id` references `files.source_file_id`; it is `NOT NULL`
+when `resources.resource_provenance_mode=SOURCE_FILE_BOUND` and null only when
+that field is `INLINE_DECLARATION`. `resources.rights_resource_id` references a globally unique resource
+of type `RIGHTS`; it may be null only when the resource itself is documented
+as `PUBLIC_DOMAIN` in `resources.definition`.
 
 ### Controlled enumerations
 
@@ -255,6 +324,9 @@ exactly one parent; `NULLABLE` states the sole permitted null condition.
 | `block_type` | `SESSION`; `COFFEE_LOT`; `GRINDER_STATE`; `OPERATOR_STATE`; `APPARATUS_CALIBRATION_STATE` |
 | `location_id` | `UPPER_BED`; `MID_BED`; `LOWER_BED`; `BULK_EQUIVALENT` |
 | `resource_type` | `ACCESS_POLICY`; `APPARATUS_STATE`; `CALIBRATION_SET`; `COMMAND_PROGRAM`; `CUSTODIAN`; `DENSITY_SOURCE`; `FIXTURE_COMPLIANCE`; `FREEZE_IDENTITY`; `GRINDER`; `GRINDER_STATE`; `HUMAN_DISPOSITION`; `HYDRAULIC_INITIAL_STATE`; `OPERATION`; `OPERATOR_ROLE`; `PREPARATION_PROTOCOL`; `REFERENCE_STATE`; `REFERENCE_STANDARD`; `RIGHTS`; `SENSOR`; `SOFTWARE`; `UNCERTAINTY`; `COFFEE_LOT`; `BASKET`; `CLOCK` |
+| `upstream_pressure_availability` | `MEASURED`; `NOT_MEASURED`; `SENSOR_FAILURE` |
+| `calibration_applicability` | `APPLICABLE`; `NOT_APPLICABLE`; `UNKNOWN_PENDING_REVIEW` |
+| `resource_provenance_mode` | `INLINE_DECLARATION`; `SOURCE_FILE_BOUND` |
 
 ### Route-conditional partition representation
 
@@ -292,13 +364,52 @@ assigns its enclosing partition to `SEALED_SCORING`.
 
 Measured pressure samples have one source of truth:
 `val_data_001_signals.csv`. `val_data_001_controls.csv` contains command and
-state records plus `basket_pressure_signal_id` and
-`upstream_pressure_signal_id`; it contains no independently authoritative
-measured-pressure value. `control_deviation_pa` is derived from the referenced
-basket signal and commanded pressure and therefore requires `processing_id`.
+state records plus the complete basket reference
+(`shot_id`, `basket_pressure_signal_id`, `basket_pressure_sample_index`) and
+complete upstream reference (`shot_id`, `upstream_pressure_signal_id`,
+`upstream_pressure_sample_index`); it contains no independently authoritative
+measured-pressure value. The basket reference is always present and resolves
+to `physical_node=P_BASKET_BED_TOP_PA_GAUGE`. Upstream ID and index are both
+present or both absent; a present reference resolves to
+`physical_node=P_MACHINE_UPSTREAM_RU_PA_GAUGE`, and absence is allowed only
+for `upstream_pressure_availability=NOT_MEASURED`. `SENSOR_FAILURE` retains a
+referenced signal sample whose `missing_value_state=SENSOR_FAILURE`.
+
+A control reference with `raw_or_processed=PROCESSED_SYNCHRONIZED` points to a
+signal row with the same state and mandatory `processing_id`.
+`control_deviation_pa` identifies the exact basket sample above and is derived
+from that sample and `commanded_pressure_value`; any populated deviation
+therefore requires the control row's `processing_id` to identify the deriving
+operation.
 If duplicated presentation values are exported later, they must be byte- and
 value-derived from that signal row; conflicts resolve in favor of the signal
 table and invalidate the export.
+
+### Cross-table relational invariants
+
+1. `evidence_partitions.(campaign_id, route_id)` must match the campaign
+   candidate key; existence of each identifier separately is insufficient.
+2. A replicate's (`condition_id`, `campaign_id`) and (`block_id`,
+   `campaign_id`) must match the corresponding condition and block candidate
+   keys.
+3. A replicate's (`evidence_partition_id`, `campaign_id`, `route_id`) must
+   match one partition candidate key, and its (`campaign_id`, `route_id`) must
+   match its campaign.
+4. A shot's duplicated campaign, route, condition, block, and partition fields
+   must exactly equal those inherited through the complete replicate candidate
+   key. Its (`condition_id`, `campaign_id`, `apparatus_id`) must also match the
+   condition candidate key, and its apparatus must equal the campaign's
+   apparatus. Any mismatch rejects the row.
+5. Every referenced pressure sample has the same `shot_id` as the control row.
+   For `control_mode=PRESCRIBED_BASKET_PRESSURE`, the condition and every
+   control row use `prescribed_node=P_BASKET_BED_TOP_PA_GAUGE`, and the basket
+   reference resolves to that physical node.
+6. For `control_mode=MACHINE_COUPLED`, the condition and every control row use
+   `prescribed_node=NOT_APPLICABLE_MACHINE_COUPLED`; basket pressure remains a
+   measured signal, never a prescribed value.
+7. Route-specific partition roles, evidence classes, and sealing states must
+   satisfy the selected route rules below. Ordinary replicates and blocks do
+   not acquire holdout status independently of their partition.
 
 ## Timebase, timing, calibration, and latency
 

--- a/docs/validation/cases/VAL_CASE_001_HYDRAULIC_COMPACTION_IDENTIFIABILITY_RESULTS.md
+++ b/docs/validation/cases/VAL_CASE_001_HYDRAULIC_COMPACTION_IDENTIFIABILITY_RESULTS.md
@@ -220,3 +220,26 @@ interpretation, evidence, or claim ceiling is changed by this administrative
 closure. Physical validation remains `NOT_ESTABLISHED`, structural
 identifiability remains `NOT_ASSESSED`, and the next scientific gate is
 `ADDITIONAL_INDEPENDENT_DATA_REQUIRED`.
+
+## Post-closure campaign cross-reference erratum
+
+The earlier campaign-ID mapping is superseded only for campaign references.
+No numerical result, scientific method, or interpretation changes, and the v2
+result SHA-256 remains
+`bb7bba7481a56ac8729758a6d5cd36e7d046b889256a7c1d1c8ed7cff998375a`.
+
+- EXP-001: Synchronized whole-shot telemetry and cup chemistry. This supplies
+  complementary whole-shot basket-pressure, flow/mass, temperature, and
+  cup-chemistry planning.
+- EXP-002: Initially dry puck infiltration and physical first drip.
+- EXP-003: Grinder-specific particle-size, packing, and permeability map,
+  including PSD, fines fraction, packing, porosity, permeability, and
+  pressure-flow input characterization.
+- EXP-004: Poroelastic deformation, pressure, and flow. This is the principal
+  existing campaign for deformation/pressure/flow.
+- EXP-005: Time-dependent bed-mechanism discrimination (`kappa(t)`), deferred
+  beyond the minimum initial measurement package.
+
+No current Puckworks campaign completely covers separate upstream
+machine-side pressure and machine response:
+`PUCKWORKS_MACHINE_MODE_CAMPAIGN_GAP`.


### PR DESCRIPTION
Closes #47

## Scope and exact identities

- Task: `VAL-DATA-001` state and serialization consistency correction
- Review status: `CORRECTED_PENDING_EXACT_HEAD_REVIEW`
- Change declaration: `NO_GOVERNING_PHYSICS_CHANGE`
- Base commit/tree: `afc6245e1591154112e15c873e9f17dbeb4efa05` / `2a93f855ea81c60a6563f6f218b2b2fadb309fd4`
- Previous head/tree: `57a45139a2ecb892e29fa62d13b36dfaa0ef199a` / `37675886fa779e5d1971c34eae67da52fd312636`
- Corrected head/tree: `b0d53ad1be1a8c64b8c36c2395f6475f7856a67c` / `0e560265b0788609c74d26023d826615899e8580`
- Commit count: 10
- Corrected plan SHA-256: `978d0711787a6604f088720327d4689102729646d4df57f96a6e121e119c5fc5`
- VAL-CASE-001 result unchanged: `bb7bba7481a56ac8729758a6d5cd36e7d046b889256a7c1d1c8ed7cff998375a`
- Accepted report/erratum unchanged: `b06a2049270ed62a8ae447b6ab6ea82237d47454267849a8615241102d6078ce`
- Puckworks lock unchanged: `fc61c4670ec7bf801e40bb391aab16048b8da26b` / `1d553e44ee2f7480a5df521560801b478618cc84`

## State and serialization consistency

- Package operation foreign keys are mode-conditional: full export uses `COMPATIBILITY_EXPORT`; metadata-only uses `SEALED_METADATA_ASSEMBLY`; non-generated modes use null.
- The processing graph has disjoint `NORMALIZED_FILE_ASSEMBLY -> COMPATIBILITY_EXPORT` and `NORMALIZED_FILE_ASSEMBLY -> SEALED_METADATA_ASSEMBLY` branches with no scope mixing.
- Valid stored export statuses are exactly `GENERATED_VERIFIED`, `NOT_GENERATED`, and `NOT_APPLICABLE`; unreachable `PROHIBITED_SEALED` was removed.
- Exported-row mapping is total: `RAW_NATIVE -> raw`, `PROCESSED_SYNCHRONIZED -> processed`, and `DERIVED_WITH_SYNCHRONIZED_SOURCES -> processed`. Missingness remains field-level only.
- `apparatus.yml.signals[].calibration` is exactly `"see calibration.csv"` for applicable calibration, exactly `"NOT_APPLICABLE"` when inapplicable, and export is prohibited while applicability is unresolved.
- YAML serialization freezes UTF-8/no BOM, LF with one final LF, two-space indentation, block sequences, quoted strings, key order, and prohibition of markers, anchors, aliases, tags, comments, trailing whitespace, and trailing blank lines.
- Package QA and source manifest both bind 226 files and aggregate `1cba84ad8a7d314ba5a9f2d0111c79559959214bbc75cac52f6bf131ec9a6544`.

## Changed paths

- `docs/validation/VAL_DATA_001_SYNCHRONIZED_HYDRAULIC_COMPACTION_MEASUREMENT_PLAN.md`
- `docs/PROJECT_STATE.md`
- `docs/QA_STATUS.md`
- `docs/DEVELOPMENT_HISTORY.md`
- `PACKAGE_QA_STATUS.json`
- `SOURCE_PACKAGE_MANIFEST.json`
- `docs/validation/cases/VAL_CASE_001_HYDRAULIC_COMPACTION_IDENTIFIABILITY_RESULTS.md` (accepted append-only campaign cross-reference erratum)

## Verification

- Deterministic mode/state/calibration/YAML/aggregate audit: PASS
- Package modes: 4/4 PASS
- Export branches: 2/2 PASS
- Reachable export statuses: 3/3 PASS
- Exported-row mappings: 3/3 PASS
- Calibration applicability dispositions: 3/3 PASS
- Duplicate conceptual YAML serialization: byte-identical PASS
- Python: 324/324 PASS
- Static gates: 38/38 PASS
- Source manifest: 226/226 PASS
- Source aggregate: `1cba84ad8a7d314ba5a9f2d0111c79559959214bbc75cac52f6bf131ec9a6544`
- Stage-0, JSON, shell, whitespace, source/boundary, immutable report/result, solver/configuration/framework/standard, claim, and Puckworks-lock checks: PASS

No OpenFOAM, reducer, solver, scientific case, external-artifact access,
commissioning, data collection, procurement, fitting, retuning, scoring,
protected/holdout access, Puckworks change, result change, governing-physics
change, or VAL-CASE-002 work occurred.

`EXPERIMENTAL_COMMISSIONING: NOT_AUTHORIZED`  
`PHYSICAL_VALIDATION: NOT_ESTABLISHED`  
`VAL_CASE_002: NOT_STARTED`