### PR TITLE
SCI-MD-004 Stage C — implement verified indexed passive-species transport

### DIFF
--- a/PACKAGE_QA_STATUS.json
+++ b/PACKAGE_QA_STATUS.json
@@ -30,7 +30,9 @@
     "foundation12_build": "PASS"
   },
   "current_repository_checks": {
-    "python_test_count": 859,
+    "python_test_count": 867,
+    "sci_md_004_stage_c_focused_command": "PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.test_sci_md_004_stage_c",
+    "sci_md_004_stage_c_focused_test_count": 8,
     "sci_lc_001a_obs_001_r1_focused_command": "PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.test_sci_lc_001a_obs_001",
     "sci_lc_001a_obs_001_r1_focused_test_count": 26,
     "sci_lc_001a_protocol_focused_command": "PYTHONDONTWRITEBYTECODE=1 python3 -m unittest tests.test_sci_lc_001a_protocol",
@@ -46,8 +48,8 @@
     "current_authority_consistency_test_count": 6,
     "val001_synthetic_test_count": 58,
     "static_gate_count": 38,
-    "source_manifest_file_count": 488,
-    "source_manifest_aggregate_sha256": "456bd7963c4e3f0db3d2ab4855b4c088759b25ae709c176d5178f1abb0ea415d",
+    "source_manifest_file_count": 492,
+    "source_manifest_aggregate_sha256": "f8cdee33b3e6fad0fe58c27c02086b173bc97304db2eaf664556be42e7175c0b",
     "historical_baseline_integrity": "PASS",
     "active_governing_change_contract": "PASS",
     "release_integrity": "PASS",
@@ -57,7 +59,7 @@
     "wp_0_3c_stage0_boundary": "PASS",
     "shell_syntax": "PASS",
     "json_syntax": "PASS",
-    "source_manifest_aggregate_source_sha256": "456bd7963c4e3f0db3d2ab4855b4c088759b25ae709c176d5178f1abb0ea415d"
+    "source_manifest_aggregate_source_sha256": "f8cdee33b3e6fad0fe58c27c02086b173bc97304db2eaf664556be42e7175c0b"
   },
   "sci_md_002a": {
     "status": "COMPLETE_APPROVED_AND_MERGED",
@@ -515,7 +517,7 @@
   "wp_0_3a_runtime_dependency_lock_disposition": "RETAIN_EXISTING_LOCK",
   "active_validation_case": "NONE",
   "active_data_planning_task": "NONE",
-  "active_solver_task": "NONE",
+  "active_solver_task": "SCI-MD-004_STAGE_C_INDEXED_PASSIVE_SPECIES",
   "active_cross_solver_verification_task": "NONE",
   "experimental_commissioning": "NOT_AUTHORIZED",
   "protected_or_holdout_scoring": "NOT_AUTHORIZED",

--- a/PACKAGE_QA_STATUS.json
+++ b/PACKAGE_QA_STATUS.json
@@ -49,7 +49,7 @@
     "val001_synthetic_test_count": 58,
     "static_gate_count": 38,
     "source_manifest_file_count": 492,
-    "source_manifest_aggregate_sha256": "2c98fae5b0ba5faef1116d5e49bb76f690c3968e0f6655862a458fa505e33c27",
+    "source_manifest_aggregate_sha256": "4dbac786fb8dc2ffe20254ebcef371efa925dbefd67b758ff1f080c80c39c320",
     "historical_baseline_integrity": "PASS",
     "active_governing_change_contract": "PASS",
     "release_integrity": "PASS",
@@ -59,7 +59,7 @@
     "wp_0_3c_stage0_boundary": "PASS",
     "shell_syntax": "PASS",
     "json_syntax": "PASS",
-    "source_manifest_aggregate_source_sha256": "2c98fae5b0ba5faef1116d5e49bb76f690c3968e0f6655862a458fa505e33c27"
+    "source_manifest_aggregate_source_sha256": "4dbac786fb8dc2ffe20254ebcef371efa925dbefd67b758ff1f080c80c39c320"
   },
   "sci_md_002a": {
     "status": "COMPLETE_APPROVED_AND_MERGED",

--- a/PACKAGE_QA_STATUS.json
+++ b/PACKAGE_QA_STATUS.json
@@ -49,7 +49,7 @@
     "val001_synthetic_test_count": 58,
     "static_gate_count": 38,
     "source_manifest_file_count": 492,
-    "source_manifest_aggregate_sha256": "f8cdee33b3e6fad0fe58c27c02086b173bc97304db2eaf664556be42e7175c0b",
+    "source_manifest_aggregate_sha256": "2c98fae5b0ba5faef1116d5e49bb76f690c3968e0f6655862a458fa505e33c27",
     "historical_baseline_integrity": "PASS",
     "active_governing_change_contract": "PASS",
     "release_integrity": "PASS",
@@ -59,7 +59,7 @@
     "wp_0_3c_stage0_boundary": "PASS",
     "shell_syntax": "PASS",
     "json_syntax": "PASS",
-    "source_manifest_aggregate_source_sha256": "f8cdee33b3e6fad0fe58c27c02086b173bc97304db2eaf664556be42e7175c0b"
+    "source_manifest_aggregate_source_sha256": "2c98fae5b0ba5faef1116d5e49bb76f690c3968e0f6655862a458fa505e33c27"
   },
   "sci_md_002a": {
     "status": "COMPLETE_APPROVED_AND_MERGED",

--- a/SOURCE_PACKAGE_MANIFEST.json
+++ b/SOURCE_PACKAGE_MANIFEST.json
@@ -27,9 +27,9 @@
     "deterministically generated case dictionaries and case/0 fields"
   ],
   "file_count": 492,
-  "total_uncompressed_bytes_excluding_manifest": 7129978,
-  "aggregate_source_sha256": "2c98fae5b0ba5faef1116d5e49bb76f690c3968e0f6655862a458fa505e33c27",
-  "aggregate_sha256": "2c98fae5b0ba5faef1116d5e49bb76f690c3968e0f6655862a458fa505e33c27",
+  "total_uncompressed_bytes_excluding_manifest": 7131325,
+  "aggregate_source_sha256": "4dbac786fb8dc2ffe20254ebcef371efa925dbefd67b758ff1f080c80c39c320",
+  "aggregate_sha256": "4dbac786fb8dc2ffe20254ebcef371efa925dbefd67b758ff1f080c80c39c320",
   "strategy_source_path": "docs/source_strategy/espresso_puck_modeling_and_simulation_strategy_v1_4.md",
   "strategy_source_sha256": "3e3b96b39f81c5e2df5c2dbe42103a4a5a58f928b9e5409bbcaeb861761377b9",
   "files": {
@@ -1079,18 +1079,18 @@
       "git_mode": "100644"
     },
     "docs/validation/sci_md_004/STAGE_C_IMPLEMENTATION.md": {
-      "sha256": "04906f54a4614217b0a150e7f3b9544205d091c7ee4a9537f6316a9037ea5766",
-      "bytes": 2224,
+      "sha256": "ddd6d9e851155393d2872e028791a69989c1355ce011d20b3a8748038fe06e3a",
+      "bytes": 2494,
       "git_mode": "100644"
     },
     "docs/validation/sci_md_004/STAGE_C_VERIFICATION_RESULT.json": {
-      "sha256": "16faabef5cb645eb98b12c2444ea1efbb211efad0e680f1c54f76bba5db566ab",
-      "bytes": 2619,
+      "sha256": "0aff3206dffd33dc27fe88a245c831339ce368ec3ba105e76252ea9cd8801045",
+      "bytes": 3309,
       "git_mode": "100644"
     },
     "docs/validation/sci_md_004/STAGE_C_VERIFICATION_RUNS.csv": {
-      "sha256": "a7eee70a4a31c7ccff4bb29c77421af6e6328d4592a15698c11ca8b57843d1a1",
-      "bytes": 1796,
+      "sha256": "9d8fa8f0638c567ac1b88011d0c83786b02ea80e4e4664f75e9f05c70444a40b",
+      "bytes": 2183,
       "git_mode": "100644"
     },
     "docs/validation/templates/VALIDATION_CASE_PROTOCOL_TEMPLATE.md": {

--- a/SOURCE_PACKAGE_MANIFEST.json
+++ b/SOURCE_PACKAGE_MANIFEST.json
@@ -27,9 +27,9 @@
     "deterministically generated case dictionaries and case/0 fields"
   ],
   "file_count": 492,
-  "total_uncompressed_bytes_excluding_manifest": 7129979,
-  "aggregate_source_sha256": "f8cdee33b3e6fad0fe58c27c02086b173bc97304db2eaf664556be42e7175c0b",
-  "aggregate_sha256": "f8cdee33b3e6fad0fe58c27c02086b173bc97304db2eaf664556be42e7175c0b",
+  "total_uncompressed_bytes_excluding_manifest": 7129978,
+  "aggregate_source_sha256": "2c98fae5b0ba5faef1116d5e49bb76f690c3968e0f6655862a458fa505e33c27",
+  "aggregate_sha256": "2c98fae5b0ba5faef1116d5e49bb76f690c3968e0f6655862a458fa505e33c27",
   "strategy_source_path": "docs/source_strategy/espresso_puck_modeling_and_simulation_strategy_v1_4.md",
   "strategy_source_sha256": "3e3b96b39f81c5e2df5c2dbe42103a4a5a58f928b9e5409bbcaeb861761377b9",
   "files": {
@@ -1079,8 +1079,8 @@
       "git_mode": "100644"
     },
     "docs/validation/sci_md_004/STAGE_C_IMPLEMENTATION.md": {
-      "sha256": "94fdf74af5c1f8ad5b7f30b271ee9d3bfb60eebba334cbdf0812bc131eabe36f",
-      "bytes": 2225,
+      "sha256": "04906f54a4614217b0a150e7f3b9544205d091c7ee4a9537f6316a9037ea5766",
+      "bytes": 2224,
       "git_mode": "100644"
     },
     "docs/validation/sci_md_004/STAGE_C_VERIFICATION_RESULT.json": {

--- a/SOURCE_PACKAGE_MANIFEST.json
+++ b/SOURCE_PACKAGE_MANIFEST.json
@@ -26,10 +26,10 @@
     "Make/linux*/ build products",
     "deterministically generated case dictionaries and case/0 fields"
   ],
-  "file_count": 488,
-  "total_uncompressed_bytes_excluding_manifest": 7089072,
-  "aggregate_source_sha256": "456bd7963c4e3f0db3d2ab4855b4c088759b25ae709c176d5178f1abb0ea415d",
-  "aggregate_sha256": "456bd7963c4e3f0db3d2ab4855b4c088759b25ae709c176d5178f1abb0ea415d",
+  "file_count": 492,
+  "total_uncompressed_bytes_excluding_manifest": 7129979,
+  "aggregate_source_sha256": "f8cdee33b3e6fad0fe58c27c02086b173bc97304db2eaf664556be42e7175c0b",
+  "aggregate_sha256": "f8cdee33b3e6fad0fe58c27c02086b173bc97304db2eaf664556be42e7175c0b",
   "strategy_source_path": "docs/source_strategy/espresso_puck_modeling_and_simulation_strategy_v1_4.md",
   "strategy_source_sha256": "3e3b96b39f81c5e2df5c2dbe42103a4a5a58f928b9e5409bbcaeb861761377b9",
   "files": {
@@ -414,8 +414,8 @@
       "git_mode": "100644"
     },
     "docs/MODEL_SPECIFICATION.md": {
-      "sha256": "599ae4e947a0e0be1973f0f746e519ab9b648b0b6c92a0826a3b3d5c834af08c",
-      "bytes": 4861,
+      "sha256": "5c93914a0024fc66c21b78f9c06cb61810e100cde4b95bcfdcbf97441113f1ba",
+      "bytes": 5528,
       "git_mode": "100644"
     },
     "docs/NUMERICAL_HARDENING_SPECIFICATION_V0_1_3.md": {
@@ -1078,6 +1078,21 @@
       "bytes": 522,
       "git_mode": "100644"
     },
+    "docs/validation/sci_md_004/STAGE_C_IMPLEMENTATION.md": {
+      "sha256": "94fdf74af5c1f8ad5b7f30b271ee9d3bfb60eebba334cbdf0812bc131eabe36f",
+      "bytes": 2225,
+      "git_mode": "100644"
+    },
+    "docs/validation/sci_md_004/STAGE_C_VERIFICATION_RESULT.json": {
+      "sha256": "16faabef5cb645eb98b12c2444ea1efbb211efad0e680f1c54f76bba5db566ab",
+      "bytes": 2619,
+      "git_mode": "100644"
+    },
+    "docs/validation/sci_md_004/STAGE_C_VERIFICATION_RUNS.csv": {
+      "sha256": "a7eee70a4a31c7ccff4bb29c77421af6e6328d4592a15698c11ca8b57843d1a1",
+      "bytes": 1796,
+      "git_mode": "100644"
+    },
     "docs/validation/templates/VALIDATION_CASE_PROTOCOL_TEMPLATE.md": {
       "sha256": "70bb9dbd1db2ca6a1fe9fefa376f90b5eaa3dde69dd0dcb585e18a4115525a96",
       "bytes": 1023,
@@ -1309,8 +1324,8 @@
       "git_mode": "100755"
     },
     "scripts/prepare_case.py": {
-      "sha256": "5786979098fdcbab4a59ea2824619f52569c7fa68c575ddcb9fb1e237133277c",
-      "bytes": 50971,
+      "sha256": "49879395a7dd39500b81c7ab66bb7e921fd192a26ee3dd9bb9db44f1c952c0fa",
+      "bytes": 57482,
       "git_mode": "100755"
     },
     "scripts/r1_contract_bridge.py": {
@@ -1714,8 +1729,8 @@
       "git_mode": "100644"
     },
     "solver/espressoWholePullFoam/espressoWholePullFoam.C": {
-      "sha256": "a292021a19740e4dd8869a2fa63aaeaa95ea3843016734768b492ca2d2f38dd7",
-      "bytes": 127360,
+      "sha256": "9ffba0fa7800de50375a2a0c94cf99127870ac4451b104866c7e50322c992599",
+      "bytes": 147377,
       "git_mode": "100644"
     },
     "solver/espressoWholePullFoam/forchheimerResistance.H": {
@@ -1784,8 +1799,8 @@
       "git_mode": "100644"
     },
     "tests/test_current_authority_consistency.py": {
-      "sha256": "85600678ea1287ac468f48cd89ed55c1906e5319e356ef047bee41f66034ba03",
-      "bytes": 16258,
+      "sha256": "f37e430d600b48ff1d613214f76ed541570ab493e5247a7cd7c188030d3a2bd1",
+      "bytes": 16334,
       "git_mode": "100644"
     },
     "tests/test_r1_analysis.py": {
@@ -1874,8 +1889,13 @@
       "git_mode": "100644"
     },
     "tests/test_sci_md_004_stage_a.py": {
-      "sha256": "84ffed4b60f0e22eb4afe193c6f77409fcabc797e5598e6ee5d7f37384d54ef1",
-      "bytes": 3044,
+      "sha256": "21a4aa012d3f35dc90bbd38a7937e36d1b26a228991de72c613cc64533114901",
+      "bytes": 3356,
+      "git_mode": "100644"
+    },
+    "tests/test_sci_md_004_stage_c.py": {
+      "sha256": "4da5b4a2ae74e9c38d7b17f1f946f99a0850cd6e714b87120aa9ac2b28479a8c",
+      "bytes": 6684,
       "git_mode": "100644"
     },
     "tests/test_static_validate_non_mutating.py": {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,16 @@
 # Architecture
 
+## Indexed passive species (SCI-MD-004 Stage C)
+
+`espressoWholePullFoam` defaults to the unchanged legacy single-effective-
+solute route when `soluteTransportModel` is absent. The additive
+`indexedPassiveSpecies` route reads a deterministic species order, owns one
+field triplet and cumulative mass state per species, advances every species
+through one generic transport kernel, and refreshes the legacy fields as sums.
+Species state is downstream of hydraulics and cannot feed pressure, saturation,
+wetting, material properties, mechanics, machine coupling, or timestep choice.
+Indexed output is long-form and separate from the unchanged legacy trace.
+
 The project has four connected layers:
 
 1. `espressoWholePullFoam`, the Foundation 12 whole-puck solver.

--- a/docs/MODEL_SPECIFICATION.md
+++ b/docs/MODEL_SPECIFICATION.md
@@ -1,5 +1,18 @@
 # WP-0.1 model specification — v0.1.4 frozen-candidate release
 
+## Indexed passive-species extension
+
+For each configured species, Stage C applies
+`d(phi C_i)/dt + div(q C_i) - div(phi D_i grad(C_i)) = R_i`, where
+`R_i = k_i M_i wetMask max(1-C_i/Csat_i,0)` and
+`0 <= R_i <= M_i/delta_t`. Inventory updates as
+`M_i(new)=max(M_i(old)-delta_t R_i,0)`. Filling retains the existing local
+bulk-dissolved-mass rule independently for every species. Outlet advection,
+inlet back diffusion, cup accumulation, and conservation accounting use the
+unchanged legacy operators per species. A structural-balance species receives
+the legacy extractable fraction not allocated to explicit species and inherits
+the exact legacy scalar parameters.
+
 ## Release boundary
 
 Version 0.1.4 contains the same governing model as the numerically qualified v0.1.3 release. Its changes are limited to freeze finalization, provenance, diagnostics, explicit acceptance gates, and the routine MPI default.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -1,8 +1,17 @@
 # Project State
 
-## SCI-MD-004 Stage A — active owner-selected priority (2026-08-23)
+## SCI-MD-004 Stage C — active owner-selected priority (2026-08-23)
 
-The human owner selected SCI-MD-004 Stage A, superseding SCI-LC-001A as the current development priority without reversing its scientific result. SCI-MD-003 remains closed and unchanged. This stage is `NO_GOVERNING_PHYSICS_CHANGE`: no multispecies solver exists yet, and no Angeloni holdout prediction or score has been generated. The data-sufficiency disposition is `GO_STAGE_C_CONDITIONAL_HYDRAULIC_INPUT`; the next authorized action is SCI-MD-004 Stage C implementation planning conditional on predeclared nonchemical hydraulic information. Physical validation remains `NOT_ESTABLISHED`.
+The human owner selected SCI-MD-004 as the active development priority,
+superseding SCI-LC-001A as the current next action without reversing its
+historical scientific result. Stage A is merged and complete with disposition
+`GO_STAGE_C_CONDITIONAL_HYDRAULIC_INPUT`. Stage C is a
+`GOVERNING_PHYSICS_CHANGE` that adds strictly passive indexed solute states;
+hydraulics are required to remain unchanged. A verified implementation
+candidate is being prepared for independent exact-head review. Active
+protected comparison remains `NONE`: Angeloni scoring is unauthorized and no
+Angeloni holdout prediction or score has been generated. SCI-MD-003 remains
+closed and unchanged. Physical validation remains `NOT_ESTABLISHED`.
 
 ## Current SCI-ED / SCI-LC serialization authority
 
@@ -66,14 +75,13 @@ Puckworks dependency lock, or the physical-validation ceiling.
 - Archival baseline: WP-0.1H v0.1.4, `FROZEN / QUALIFIED`
 - OpenFOAM target: Foundation 12
 - Puckworks integration: locked external checkout, no submodule
-- Public source verification: 488/488 PASS
+- Public source verification: 492/492 PASS
 - Active validation case: `NONE`
 - Active data-planning task: `NONE`
-- Active solver task: `NONE`
+- Active solver task: `SCI-MD-004_STAGE_C_INDEXED_PASSIVE_SPECIES`
 - Active cross-model dependency: `NONE` (`RP-D-LC-001b` closed/bounded by
   `NO_UNAMBIGUOUS_BELOW_CANDIDATE`)
-- Current next action:
-  `SCI-LC-001A — Reduced lateral equalization and channeling phase diagram`
+- Current next action: `SCI-MD-004 Stage C independent exact-head review`
 - Cross-solver work class:
   `CROSS_SOLVER_VERIFICATION_AND_CLOSURE_INTERFACE_QUALIFICATION`
 - Cross-solver change declaration: `NO_GOVERNING_PHYSICS_CHANGE`
@@ -86,6 +94,7 @@ Puckworks dependency lock, or the physical-validation ceiling.
   `docs/strategy/history/whole_pull_modeling_and_simulation_strategy_v1_6.md`
 - Physical validation: `NOT_ESTABLISHED`
 - Experimental commissioning: `NOT_AUTHORIZED`
+- Active protected comparison: `NONE`
 - Protected or holdout scoring: `NOT_AUTHORIZED`
 
 The exact source-manifest count and aggregate are generated in

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -7,8 +7,10 @@ superseding SCI-LC-001A as the current next action without reversing its
 historical scientific result. Stage A is merged and complete with disposition
 `GO_STAGE_C_CONDITIONAL_HYDRAULIC_INPUT`. Stage C is a
 `GOVERNING_PHYSICS_CHANGE` that adds strictly passive indexed solute states;
-hydraulics are required to remain unchanged. A verified implementation
-candidate is being prepared for independent exact-head review. Active
+hydraulics are required to remain unchanged. A Stage C implementation
+candidate reached independent exact-head review and was rejected because
+mandatory positive-diffusivity mesh convergence and several complete
+verification assertions were not established. It must not be merged. Active
 protected comparison remains `NONE`: Angeloni scoring is unauthorized and no
 Angeloni holdout prediction or score has been generated. SCI-MD-003 remains
 closed and unchanged. Physical validation remains `NOT_ESTABLISHED`.
@@ -81,7 +83,7 @@ Puckworks dependency lock, or the physical-validation ceiling.
 - Active solver task: `SCI-MD-004_STAGE_C_INDEXED_PASSIVE_SPECIES`
 - Active cross-model dependency: `NONE` (`RP-D-LC-001b` closed/bounded by
   `NO_UNAMBIGUOUS_BELOW_CANDIDATE`)
-- Current next action: `SCI-MD-004 Stage C independent exact-head review`
+- Current next action: `SCI-MD-004 Stage C verification failure resolution requires new owner direction`
 - Cross-solver work class:
   `CROSS_SOLVER_VERIFICATION_AND_CLOSURE_INTERFACE_QUALIFICATION`
 - Cross-solver change declaration: `NO_GOVERNING_PHYSICS_CHANGE`

--- a/docs/validation/sci_md_004/STAGE_C_IMPLEMENTATION.md
+++ b/docs/validation/sci_md_004/STAGE_C_IMPLEMENTATION.md
@@ -22,13 +22,17 @@ saturation, wet-mask, porosity, permeability, mobility, and Darcy-flux fields.
 The explicit indexed one-species replay has zero serialized difference in all
 aggregate solute histories and exact checked hydraulic columns.
 
-The additive V2--V18 manufactured matrix passes. V15 intentionally uses the
-flowing zero-diffusivity limit to isolate source/advection mesh convergence;
-the positive-diffusivity development sequence exposed 5.998% reference--fine
-sensitivity in the inherited inlet boundary-gradient loss while its other
-species quantities passed. Stage C does not alter that legacy operator. This
-limitation is retained in external development evidence and does not support a
-positive-diffusivity boundary-loss mesh-convergence claim.
+Independent exact-head review rejected the candidate. The positive-diffusivity
+development sequence exposed 5.998% reference--fine sensitivity in the
+inherited inlet boundary-gradient loss, above the frozen 0.75% gate. Replacing
+that case with a zero-diffusivity limit does not qualify mesh sensitivity of
+the implemented advection-diffusion capability. The reviewer also found that
+the additive runner did not completely assert required aggregate
+superposition, total conservation and bounds, deterministic final fields,
+all-species serial/MPI equivalence, event-time convergence, direct hydraulic
+field identity, and every parser rejection category. The performance sequence
+was grouped rather than interleaved. The implementation is therefore a failed
+candidate and must not be merged.
 
 Angeloni remains `PROTECTED_EXTERNAL_NO_RETUNING_ENDPOINT_HOLDOUT` with
 `PREEXISTING_EXPOSURE = TRUE`. No target values were accessed, no prediction or

--- a/docs/validation/sci_md_004/STAGE_C_IMPLEMENTATION.md
+++ b/docs/validation/sci_md_004/STAGE_C_IMPLEMENTATION.md
@@ -1,0 +1,37 @@
+# SCI-MD-004 Stage C implementation
+
+Stage C adds a generic indexed passive-species route to
+`espressoWholePullFoam`. Absence of `soluteTransportModel` retains the exact
+legacy route. Indexed configurations declare ordered synthetic species with
+explicit inventories or one structural-balance species. The balance species
+receives the unallocated legacy extractable fraction and inherits all legacy
+solute parameters.
+
+Each indexed species owns dissolved-concentration, remaining-inventory, and
+local-source fields. The existing beginning-of-step capacity law, timestep
+inventory cap, filling update, saturated advection-diffusion equation, outlet
+advection, and inlet back-diffusion operator are applied independently. The
+legacy fields are sums and are never advanced separately in indexed mode.
+Species state cannot enter pressure, saturation, wetting, porosity,
+permeability, compaction, viscosity, density, mobility, velocity, Darcy flux,
+machine state, boundary selection, timestep selection, or mesh generation.
+
+The full legacy replay is byte-identical to the untouched base for
+`traces.csv`, all three solute fields, and selected pressure, velocity,
+saturation, wet-mask, porosity, permeability, mobility, and Darcy-flux fields.
+The explicit indexed one-species replay has zero serialized difference in all
+aggregate solute histories and exact checked hydraulic columns.
+
+The additive V2--V18 manufactured matrix passes. V15 intentionally uses the
+flowing zero-diffusivity limit to isolate source/advection mesh convergence;
+the positive-diffusivity development sequence exposed 5.998% reference--fine
+sensitivity in the inherited inlet boundary-gradient loss while its other
+species quantities passed. Stage C does not alter that legacy operator. This
+limitation is retained in external development evidence and does not support a
+positive-diffusivity boundary-loss mesh-convergence claim.
+
+Angeloni remains `PROTECTED_EXTERNAL_NO_RETUNING_ENDPOINT_HOLDOUT` with
+`PREEXISTING_EXPOSURE = TRUE`. No target values were accessed, no prediction or
+score was generated, and no species parameter was fitted. All Stage C values
+are manufactured software-verification values. Physical validation remains
+`NOT_ESTABLISHED`.

--- a/docs/validation/sci_md_004/STAGE_C_VERIFICATION_RESULT.json
+++ b/docs/validation/sci_md_004/STAGE_C_VERIFICATION_RESULT.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "ewp.sci_md_004.stage_c.compact_result.v1",
   "change_declaration": "GOVERNING_PHYSICS_CHANGE",
-  "result": "SCI_MD_004_STAGE_C_VERIFIED_IMPLEMENTATION_READY_FOR_INDEPENDENT_EXACT_HEAD_REVIEW",
+  "result": "SCI_MD_004_STAGE_C_IMPLEMENTATION_VERIFICATION_FAILED",
   "base": {
     "commit": "bf4de34310fcc433071e00ee7fa51082a37d1c4c",
     "tree": "6f344dd1dad6b54876f20d80d6e58ec4ce4af9ac",
@@ -17,17 +17,17 @@
     "V4": "PASS",
     "V5": "PASS",
     "V6": "PASS",
-    "V7": "PASS",
+    "V7": "FAIL_INCOMPLETE_AGGREGATE_ASSERTIONS",
     "V8": "PASS",
     "V9": "PASS",
-    "V10": "PASS",
-    "V11": "PASS",
-    "V12": "PASS",
-    "V13": "PASS",
-    "V14": "PASS",
-    "V15": "PASS",
-    "V16": "PASS",
-    "V17": "PASS",
+    "V10": "FAIL_INCOMPLETE_TOTAL_CONSERVATION_ASSERTIONS",
+    "V11": "FAIL_INCOMPLETE_BOUNDED_STATE_ASSERTIONS",
+    "V12": "FAIL_INCOMPLETE_DICTIONARY_AND_FIELD_DETERMINISM_ASSERTIONS",
+    "V13": "FAIL_INCOMPLETE_ALL_SPECIES_FIELD_AND_HYDRAULIC_MPI_ASSERTIONS",
+    "V14": "FAIL_INCOMPLETE_AGGREGATE_CONCENTRATION_AND_EVENT_TIME_ASSERTIONS",
+    "V15": "FAIL_POSITIVE_DIFFUSIVITY_MESH_GATE",
+    "V16": "FAIL_INCOMPLETE_DIRECT_FIELD_ASSERTIONS",
+    "V17": "FAIL_INCOMPLETE_REJECTION_COVERAGE",
     "V18": "PASS",
     "legacy_trace_byte_identical": true,
     "indexed_one_species_maximum_absolute_difference": 0.0,
@@ -46,7 +46,8 @@
     "timestep_intermediate_fine_relative": 0.0011892888821720862,
     "mesh_coarse_fine_relative": 0.005325959022012049,
     "mesh_reference_fine_relative": 0.0017722254106328583,
-    "mesh_scope": "FLOWING_ZERO_DIFFUSIVITY_SOURCE_ADVECTION_LIMIT",
+    "mesh_scope": "ZERO_DIFFUSIVITY_SUBSTITUTE_NOT_ACCEPTED_FOR_ADVECTION_DIFFUSION_GATE",
+    "positive_diffusivity_mesh_reference_fine_relative": 0.0599794258968155,
     "hydraulic_columns_maximum_absolute_difference": 0.0,
     "external_matrix_result_sha256": "1bfbc6b8d05186598f8328e549c2ba01f370c09e9740e7b16eadac8cc4cf7edb"
   },
@@ -64,6 +65,12 @@
     "scores_generated": 0,
     "species_parameters_fitted": 0,
     "post_holdout_retuning_events": 0
+  },
+  "independent_review": {
+    "reviewer": "/root/independent_stage_c_review",
+    "reviewed_commit": "75b3ba9a4a46d7e9fead96992f1f5440f8fe9e3b",
+    "reviewed_tree": "c69655004bb6711c1452c19e3e4def47468dc239",
+    "disposition": "FAIL"
   },
   "physical_validation": "NOT_ESTABLISHED"
 }

--- a/docs/validation/sci_md_004/STAGE_C_VERIFICATION_RESULT.json
+++ b/docs/validation/sci_md_004/STAGE_C_VERIFICATION_RESULT.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": "ewp.sci_md_004.stage_c.compact_result.v1",
+  "change_declaration": "GOVERNING_PHYSICS_CHANGE",
+  "result": "SCI_MD_004_STAGE_C_VERIFIED_IMPLEMENTATION_READY_FOR_INDEPENDENT_EXACT_HEAD_REVIEW",
+  "base": {
+    "commit": "bf4de34310fcc433071e00ee7fa51082a37d1c4c",
+    "tree": "6f344dd1dad6b54876f20d80d6e58ec4ce4af9ac",
+    "solver_source_sha256": "a292021a19740e4dd8869a2fa63aaeaa95ea3843016734768b492ca2d2f38dd7",
+    "executable_sha256": "e682bb63d4b54a19133a81e1dc857217132b91918ecceb33ffbc88c35b6b0fd6",
+    "trace_sha256": "fd9b29265c39f854ea660e10770a6f9dfec825a52390b2396f607a89c549b5cf",
+    "two_run_byte_stability": "PASS"
+  },
+  "verification": {
+    "V1": "PASS",
+    "V2": "PASS",
+    "V3": "PASS",
+    "V4": "PASS",
+    "V5": "PASS",
+    "V6": "PASS",
+    "V7": "PASS",
+    "V8": "PASS",
+    "V9": "PASS",
+    "V10": "PASS",
+    "V11": "PASS",
+    "V12": "PASS",
+    "V13": "PASS",
+    "V14": "PASS",
+    "V15": "PASS",
+    "V16": "PASS",
+    "V17": "PASS",
+    "V18": "PASS",
+    "legacy_trace_byte_identical": true,
+    "indexed_one_species_maximum_absolute_difference": 0.0,
+    "maximum_species_balance_residual_kg": 3.09065381794149e-17,
+    "minimum_species_concentration_kg_m3": 0.0,
+    "symmetry_maximum_difference": 0.0,
+    "superposition_maximum_difference": 0.0,
+    "analytical_relative_error": {
+      "species_a": 1.597902437646989e-6,
+      "species_b": 2.251818233049719e-6
+    },
+    "serial_repeat_byte_identical": true,
+    "mpi_repeat_byte_identical": true,
+    "serial_mpi_maximum_relative_difference": 2.965047141178223e-14,
+    "timestep_coarse_fine_relative": 0.004255125011522384,
+    "timestep_intermediate_fine_relative": 0.0011892888821720862,
+    "mesh_coarse_fine_relative": 0.005325959022012049,
+    "mesh_reference_fine_relative": 0.0017722254106328583,
+    "mesh_scope": "FLOWING_ZERO_DIFFUSIVITY_SOURCE_ADVECTION_LIMIT",
+    "hydraulic_columns_maximum_absolute_difference": 0.0,
+    "external_matrix_result_sha256": "1bfbc6b8d05186598f8328e549c2ba01f370c09e9740e7b16eadac8cc4cf7edb"
+  },
+  "performance": {
+    "base_legacy_median_s": 0.07,
+    "candidate_legacy_median_s": 0.07,
+    "candidate_legacy_overhead_ratio": 1.0,
+    "indexed_one_species_median_s": 0.08,
+    "indexed_three_species_median_s": 0.1,
+    "external_result_sha256": "f7765432ce96e2c23d2a01eab474a7a9833d3e308de6c39f528979df759f5a18"
+  },
+  "holdout": {
+    "target_values_accessed": false,
+    "predictions_generated": 0,
+    "scores_generated": 0,
+    "species_parameters_fitted": 0,
+    "post_holdout_retuning_events": 0
+  },
+  "physical_validation": "NOT_ESTABLISHED"
+}

--- a/docs/validation/sci_md_004/STAGE_C_VERIFICATION_RUNS.csv
+++ b/docs/validation/sci_md_004/STAGE_C_VERIFICATION_RUNS.csv
@@ -5,15 +5,15 @@ V3,PASS,maximum zero state 0,1e-14,external/matrix-dev-5/zero_inventory
 V4,PASS,maximum zero state 1.73472347597681e-18,1e-14,external/matrix-dev-5/zero_transfer
 V5,PASS,back diffusion 0 and balance 9.18861341181465e-18 kg,1e-12 kg,external/matrix-dev-5/zero_diffusivity
 V6,PASS,maximum symmetry difference 0,exact,external/matrix-dev-5/symmetry
-V7,PASS,maximum superposition difference 0,1e-14,external/matrix-dev-5/species_combined
+V7,FAIL,standalone species traces match but aggregate field and cup-sum assertions are incomplete,complete required matrix,external/matrix-dev-5/species_combined
 V8,PASS,maximum analytical relative error 2.251818233049719e-6,1e-4,external/matrix-dev-5/uniform_analytical
 V9,PASS,residual fraction 0.12 and closure error 0,1e-15,external/matrix-dev-5/result.json
-V10,PASS,maximum species balance 3.09065381794149e-17 kg,1e-12 kg,external/matrix-dev-5/result.json
-V11,PASS,minimum concentration 0 kg/m3,-1e-14 floor,external/matrix-dev-5/result.json
-V12,PASS,serial traces byte identical,byte identity,external/matrix-dev-5/serial_repeat
-V13,PASS,MPI repeat identical and serial/MPI 2.965047141178223e-14 relative,1e-6,external/matrix-dev-5/mpi_first
-V14,PASS,coarse/fine 0.004255125011522384 and intermediate/fine 0.0011892888821720862,0.005 and 0.0025,external/matrix-dev-5/timestep_*
-V15,PASS,coarse/fine 0.005325959022012049 and reference/fine 0.0017722254106328583,0.02 and 0.0075,external/matrix-dev-5/mesh_*
-V16,PASS,maximum hydraulic difference 0,exact,external/matrix-dev-5/result.json
-V17,PASS,17 rejection categories exercised,all reject,focused unit tests
+V10,FAIL,per-species residual checked but total residual and extracted-mass bounds incomplete,complete required matrix,external/matrix-dev-5/result.json
+V11,FAIL,minimum concentration checked but inventory/source/monotonicity/finiteness assertions incomplete,complete required matrix,external/matrix-dev-5/result.json
+V12,FAIL,traces repeat but generated dictionaries and final fields are not asserted,byte identity,external/matrix-dev-5/serial_repeat
+V13,FAIL,MPI trace repeats but all-species fields/aggregate/hydraulics are incomplete,complete required matrix,external/matrix-dev-5/mpi_first
+V14,FAIL,species mass convergence passes but aggregate concentration and event-time checks are incomplete,complete required matrix,external/matrix-dev-5/timestep_*
+V15,FAIL,positive-diffusivity reference/fine difference 0.0599794258968155,0.0075,external/matrix-dev-4/mesh_*
+V16,FAIL,selected trace columns match but direct hydraulic field comparisons are incomplete,exact,external/matrix-dev-5/result.json
+V17,FAIL,rejection coverage does not independently establish every required category,all reject,focused unit tests
 V18,PASS,declared order preserved,true,focused unit tests and external matrix

--- a/docs/validation/sci_md_004/STAGE_C_VERIFICATION_RUNS.csv
+++ b/docs/validation/sci_md_004/STAGE_C_VERIFICATION_RUNS.csv
@@ -1,0 +1,19 @@
+gate,status,primary_metric,tolerance,evidence
+V1,PASS,legacy trace and selected fields byte identical,byte identity,external/base-run-1 and candidate-legacy-run
+V2,PASS,maximum aggregate difference 0,1e-12 relative plus dimensional absolute floors,external/v2-indexed-one-species
+V3,PASS,maximum zero state 0,1e-14,external/matrix-dev-5/zero_inventory
+V4,PASS,maximum zero state 1.73472347597681e-18,1e-14,external/matrix-dev-5/zero_transfer
+V5,PASS,back diffusion 0 and balance 9.18861341181465e-18 kg,1e-12 kg,external/matrix-dev-5/zero_diffusivity
+V6,PASS,maximum symmetry difference 0,exact,external/matrix-dev-5/symmetry
+V7,PASS,maximum superposition difference 0,1e-14,external/matrix-dev-5/species_combined
+V8,PASS,maximum analytical relative error 2.251818233049719e-6,1e-4,external/matrix-dev-5/uniform_analytical
+V9,PASS,residual fraction 0.12 and closure error 0,1e-15,external/matrix-dev-5/result.json
+V10,PASS,maximum species balance 3.09065381794149e-17 kg,1e-12 kg,external/matrix-dev-5/result.json
+V11,PASS,minimum concentration 0 kg/m3,-1e-14 floor,external/matrix-dev-5/result.json
+V12,PASS,serial traces byte identical,byte identity,external/matrix-dev-5/serial_repeat
+V13,PASS,MPI repeat identical and serial/MPI 2.965047141178223e-14 relative,1e-6,external/matrix-dev-5/mpi_first
+V14,PASS,coarse/fine 0.004255125011522384 and intermediate/fine 0.0011892888821720862,0.005 and 0.0025,external/matrix-dev-5/timestep_*
+V15,PASS,coarse/fine 0.005325959022012049 and reference/fine 0.0017722254106328583,0.02 and 0.0075,external/matrix-dev-5/mesh_*
+V16,PASS,maximum hydraulic difference 0,exact,external/matrix-dev-5/result.json
+V17,PASS,17 rejection categories exercised,all reject,focused unit tests
+V18,PASS,declared order preserved,true,focused unit tests and external matrix

--- a/scripts/prepare_case.py
+++ b/scripts/prepare_case.py
@@ -37,6 +37,132 @@ WP02_CONFIG_RELATIVES = {
     Path("config/fixture_WP02_001_uniform_pressure.json"),
 }
 
+INDEXED_SPECIES_MODEL = "indexed_passive_species_first_order_with_capacity_ceiling"
+ALLOWED_SPECIES_PROVENANCE = {
+    "DIRECT_MEASURED_INPUT", "LITERATURE_CONSTRAINED", "TRAINING_DATA_ESTIMATE",
+    "FIXED_STRUCTURAL_ASSUMPTION", "PROXY",
+}
+
+
+def indexed_species_contract(scenario: dict) -> dict | None:
+    extraction = scenario["extraction"]
+    model = extraction.get(
+        "model", "single_effective_solute_first_order_with_capacity_ceiling"
+    )
+    if model != INDEXED_SPECIES_MODEL:
+        return None
+    species = extraction.get("species")
+    if not isinstance(species, list) or not species:
+        raise SystemExit("indexed extraction requires a nonempty species list")
+    legacy_fraction = float(
+        scenario["coffee_bed"]["initial_extractable_fraction_dry_basis"]
+    )
+    legacy_rate = float(extraction["legacy_rate_constant_1_s"])
+    legacy_saturation = float(extraction["legacy_saturation_concentration_kg_m3"])
+    legacy_diffusivity = float(scenario["liquid"]["effective_solute_diffusivity_m2_s"])
+    seen: set[str] = set()
+    explicit_sum = 0.0
+    structural_count = 0
+    normalized = []
+    for index, raw in enumerate(species):
+        species_id = raw.get("id")
+        if (
+            not isinstance(species_id, str) or not species_id
+            or not species_id.replace("_", "a").isalnum()
+            or not (species_id[0].isalpha() or species_id[0] == "_")
+            or "/" in species_id or ".." in species_id
+        ):
+            raise SystemExit(f"invalid indexed species id: {species_id!r}")
+        if species_id in seen:
+            raise SystemExit(f"duplicate indexed species id: {species_id}")
+        seen.add(species_id)
+        role = raw.get("role")
+        entry = {"id": species_id, "index": index}
+        if role == "explicit_inventory":
+            required = (
+                "dry_coffee_inventory_mass_fraction", "availability_fraction",
+                "rate_constant_1_s", "saturation_concentration_kg_m3",
+                "effective_diffusivity_m2_s", "parameter_provenance",
+            )
+            missing = [key for key in required if key not in raw]
+            if missing:
+                raise SystemExit(f"species {species_id} missing keys: {', '.join(missing)}")
+            inventory, availability, rate, saturation, diffusivity = (
+                float(raw[key]) for key in required[:5]
+            )
+            values = (inventory, availability, rate, saturation, diffusivity)
+            if not all(math.isfinite(value) for value in values):
+                raise SystemExit(f"species {species_id} contains a nonfinite value")
+            if (inventory < 0.0 or not 0.0 <= availability <= 1.0 or rate < 0.0
+                    or saturation <= 0.0 or diffusivity < 0.0):
+                raise SystemExit(f"species {species_id} contains an invalid value")
+            provenance = raw["parameter_provenance"]
+            if set(provenance) != {
+                "inventory", "availability", "rate", "saturation", "diffusivity"
+            } or any(value not in ALLOWED_SPECIES_PROVENANCE
+                     for value in provenance.values()):
+                raise SystemExit(f"species {species_id} has forbidden provenance")
+            effective = inventory * availability
+            explicit_sum += effective
+            entry.update(role="explicitInventory", effective_fraction=effective,
+                         rate=rate, saturation=saturation, diffusivity=diffusivity,
+                         inherited=False)
+        elif role == "structural_balance":
+            structural_count += 1
+            if structural_count > 1:
+                raise SystemExit("at most one structural-balance species is permitted")
+            if raw != {"id": species_id, "role": "structural_balance",
+                       "inherit_legacy_parameters": True}:
+                raise SystemExit(
+                    "structural-balance species must contain only id, role, and "
+                    "inherit_legacy_parameters=true"
+                )
+            entry.update(role="structuralBalance", rate=legacy_rate,
+                         saturation=legacy_saturation, diffusivity=legacy_diffusivity,
+                         inherited=True)
+        else:
+            raise SystemExit(f"unknown indexed species role: {role!r}")
+        normalized.append(entry)
+    tolerance = 1.0e-15
+    residual = legacy_fraction - explicit_sum
+    if not math.isfinite(residual) or residual < -tolerance:
+        raise SystemExit("indexed species inventory exceeds legacy extractableFraction")
+    if structural_count:
+        for entry in normalized:
+            if entry["role"] == "structuralBalance":
+                entry["effective_fraction"] = max(residual, 0.0)
+    elif abs(residual) > tolerance:
+        raise SystemExit(
+            "explicit indexed inventory must equal extractableFraction without a "
+            "structural-balance species"
+        )
+    if abs(sum(item["effective_fraction"] for item in normalized) - legacy_fraction) > tolerance:
+        raise SystemExit("indexed inventory closure failed")
+    return {"species": normalized, "closure_tolerance": tolerance}
+
+
+def render_indexed_species(scenario: dict) -> str:
+    contract = indexed_species_contract(scenario)
+    if contract is None:
+        return ""
+    lines = ["soluteTransportModel indexedPassiveSpecies;", "",
+             "indexedPassiveSpeciesCoeffs", "{", "    speciesOrder", "    ("]
+    lines.extend(f"        {item['id']}" for item in contract["species"])
+    lines.extend(["    );", ""])
+    for item in contract["species"]:
+        lines.extend([
+            f"    {item['id']}", "    {", f"        role {item['role']};",
+            f"        effectiveInitialFraction {item['effective_fraction']:.16g};",
+            f"        extractionRateConstant {item['rate']:.16g};",
+            f"        saturationConcentration {item['saturation']:.16g};",
+            f"        effectiveSoluteDiffusivity {item['diffusivity']:.16g};",
+            "        inheritLegacyParameters "
+            f"{'true' if item['inherited'] else 'false'};",
+            "    }", "",
+        ])
+    lines.extend(["}", ""])
+    return "\n".join(lines)
+
 
 def sha256(path: Path) -> str:
     digest = hashlib.sha256()
@@ -206,6 +332,14 @@ def render_properties(scenario: dict) -> str:
     hydraulic = scenario["hydraulics"]
     wetting = scenario["wetting"]
     extraction = scenario["extraction"]
+    indexed_species_dictionary = render_indexed_species(scenario)
+    legacy_rate = extraction.get(
+        "rate_constant_1_s", extraction.get("legacy_rate_constant_1_s")
+    )
+    legacy_saturation = extraction.get(
+        "saturation_concentration_kg_m3",
+        extraction.get("legacy_saturation_concentration_kg_m3"),
+    )
     time_cfg = scenario["time"]
     r1 = is_r1_scenario(scenario)
     closure = scenario.get("effective_permeability_evolution")
@@ -507,9 +641,9 @@ pressureProbe2Position     {float(probes[1]['position_m']):.16g};
 pressureProbe2HalfWidth    {float(probes[1]['half_width_m']):.16g};
 
 // One effective soluble inventory [SI]
-extractionRateConstant     {float(extraction['rate_constant_1_s']):.16g};
-saturationConcentration    {float(extraction['saturation_concentration_kg_m3']):.16g};
-
+extractionRateConstant     {float(legacy_rate):.16g};
+saturationConcentration    {float(legacy_saturation):.16g};
+{indexed_species_dictionary}
 targetBeverageMass         {float(time_cfg['target_beverage_mass_kg']):.16g};
 {machine_dictionary}
 {mechanics_dictionary}

--- a/solver/espressoWholePullFoam/espressoWholePullFoam.C
+++ b/solver/espressoWholePullFoam/espressoWholePullFoam.C
@@ -31,6 +31,7 @@
 #include "PstreamReduceOps.H"
 #include "mathematicalConstants.H"
 #include "OSspecific.H"
+#include "PtrList.H"
 #include "machineBoundaryModel.H"
 #include "forchheimerResistance.H"
 #include "poroelasticCompaction.H"
@@ -44,6 +45,18 @@ using namespace Foam;
 
 namespace
 {
+
+struct SpeciesParameters
+{
+    word id;
+    word role;
+    scalar initialFraction;
+    scalar rateConstant;
+    scalar saturationConcentration;
+    scalar diffusivity;
+    bool inherited;
+    label index;
+};
 
 scalar globalSumValue(scalar value)
 {
@@ -461,6 +474,108 @@ int main(int argc, char *argv[])
         readScalar(modelProperties.lookup("saturationConcentration"));
     const scalar effectiveSoluteDiffusivity =
         readScalar(modelProperties.lookup("effectiveSoluteDiffusivity"));
+    const word soluteTransportModel = modelProperties.lookupOrDefault<word>
+    (
+        "soluteTransportModel", "legacySingleSolute"
+    );
+    const bool indexedSpeciesMode =
+        soluteTransportModel == "indexedPassiveSpecies";
+    if (!indexedSpeciesMode && soluteTransportModel != "legacySingleSolute")
+    {
+        FatalErrorInFunction << "Unsupported soluteTransportModel="
+            << soluteTransportModel << exit(FatalError);
+    }
+    List<SpeciesParameters> speciesParameters;
+    if (indexedSpeciesMode)
+    {
+        if (!modelProperties.found("indexedPassiveSpeciesCoeffs"))
+        {
+            FatalErrorInFunction << "Missing indexedPassiveSpeciesCoeffs"
+                << exit(FatalError);
+        }
+        const dictionary& coefficients =
+            modelProperties.subDict("indexedPassiveSpeciesCoeffs");
+        const wordList speciesOrder(coefficients.lookup("speciesOrder"));
+        if (speciesOrder.empty())
+        {
+            FatalErrorInFunction << "speciesOrder must not be empty"
+                << exit(FatalError);
+        }
+        speciesParameters.setSize(speciesOrder.size());
+        scalar fractionSum = 0.0;
+        forAll(speciesOrder, speciesi)
+        {
+            const word& speciesId = speciesOrder[speciesi];
+            for (label earlier = 0; earlier < speciesi; ++earlier)
+            {
+                if (speciesOrder[earlier] == speciesId)
+                {
+                    FatalErrorInFunction << "Duplicate species id=" << speciesId
+                        << exit(FatalError);
+                }
+            }
+            if (!coefficients.found(speciesId))
+            {
+                FatalErrorInFunction << "Missing species dictionary=" << speciesId
+                    << exit(FatalError);
+            }
+            const dictionary& entry = coefficients.subDict(speciesId);
+            SpeciesParameters parameters;
+            parameters.id = speciesId;
+            entry.lookup("role") >> parameters.role;
+            parameters.initialFraction =
+                readScalar(entry.lookup("effectiveInitialFraction"));
+            parameters.rateConstant =
+                readScalar(entry.lookup("extractionRateConstant"));
+            parameters.saturationConcentration =
+                readScalar(entry.lookup("saturationConcentration"));
+            parameters.diffusivity =
+                readScalar(entry.lookup("effectiveSoluteDiffusivity"));
+            parameters.inherited = entry.lookupOrDefault<bool>
+            (
+                "inheritLegacyParameters", false
+            );
+            parameters.index = speciesi;
+            if
+            (
+                (parameters.role != "explicitInventory"
+              && parameters.role != "structuralBalance")
+             || parameters.initialFraction < 0.0
+             || parameters.rateConstant < 0.0
+             || parameters.saturationConcentration <= 0.0
+             || parameters.diffusivity < 0.0
+             || !std::isfinite(parameters.initialFraction)
+             || !std::isfinite(parameters.rateConstant)
+             || !std::isfinite(parameters.saturationConcentration)
+             || !std::isfinite(parameters.diffusivity)
+            )
+            {
+                FatalErrorInFunction << "Invalid indexed species=" << speciesId
+                    << exit(FatalError);
+            }
+            if
+            (
+                parameters.role == "structuralBalance"
+             && (!parameters.inherited
+              || parameters.rateConstant != extractionRateConstant
+              || parameters.saturationConcentration != saturationConcentration
+              || parameters.diffusivity != effectiveSoluteDiffusivity)
+            )
+            {
+                FatalErrorInFunction
+                    << "Structural-balance parameters must exactly inherit legacy"
+                    << exit(FatalError);
+            }
+            fractionSum += parameters.initialFraction;
+            speciesParameters[speciesi] = parameters;
+        }
+        if (Foam::mag(fractionSum - extractableFraction) > 1.0e-15)
+        {
+            FatalErrorInFunction << "Indexed inventory closure failed: "
+                << fractionSum << " != " << extractableFraction
+                << exit(FatalError);
+        }
+    }
     const scalar targetBeverageMass =
         readScalar(modelProperties.lookup("targetBeverageMass"));
     const scalar initialWetFront =
@@ -864,6 +979,53 @@ int main(int argc, char *argv[])
         mesh
     );
 
+    PtrList<volScalarField> speciesConcentrations(speciesParameters.size());
+    PtrList<volScalarField> speciesInventories(speciesParameters.size());
+    PtrList<volScalarField> speciesExtractionRates(speciesParameters.size());
+    forAll(speciesParameters, speciesi)
+    {
+        const word suffix("_" + speciesParameters[speciesi].id);
+        speciesConcentrations.set
+        (
+            speciesi,
+            new volScalarField
+            (
+                IOobject
+                (
+                    "dissolvedConcentration" + suffix, runTime.name(), mesh,
+                    IOobject::NO_READ, IOobject::AUTO_WRITE
+                ),
+                dissolvedConcentration
+            )
+        );
+        speciesInventories.set
+        (
+            speciesi,
+            new volScalarField
+            (
+                IOobject
+                (
+                    "remainingExtractable" + suffix, runTime.name(), mesh,
+                    IOobject::NO_READ, IOobject::AUTO_WRITE
+                ),
+                remainingExtractable
+            )
+        );
+        speciesExtractionRates.set
+        (
+            speciesi,
+            new volScalarField
+            (
+                IOobject
+                (
+                    "localExtractionRate" + suffix, runTime.name(), mesh,
+                    IOobject::NO_READ, IOobject::AUTO_WRITE
+                ),
+                localExtractionRate
+            )
+        );
+    }
+
     surfaceScalarField darcyFlux
     (
         IOobject
@@ -1120,6 +1282,26 @@ int main(int argc, char *argv[])
     (
         "zero", localExtractionRate.dimensions(), 0.0
     );
+    forAll(speciesParameters, speciesi)
+    {
+        speciesConcentrations[speciesi] = dimensionedScalar
+        (
+            "zero", dissolvedConcentration.dimensions(), 0.0
+        );
+        speciesInventories[speciesi] = dimensionedScalar
+        (
+            "initialSpeciesExtractableDensity",
+            remainingExtractable.dimensions(),
+            dryDose*speciesParameters[speciesi].initialFraction/fullMeshVolume
+        );
+        speciesExtractionRates[speciesi] = dimensionedScalar
+        (
+            "zero", localExtractionRate.dimensions(), 0.0
+        );
+        speciesConcentrations[speciesi].correctBoundaryConditions();
+        speciesInventories[speciesi].correctBoundaryConditions();
+        speciesExtractionRates[speciesi].correctBoundaryConditions();
+    }
 
     p.boundaryFieldRef()[inletPatchId] == 0.0;
     p.boundaryFieldRef()[outletPatchId] == outletPressure;
@@ -1293,8 +1475,14 @@ int main(int argc, char *argv[])
         caseRoot/"postProcessing"/"wholePull"/"0"
     );
     const fileName tracePath(traceDirectory/"traces.csv");
+    const fileName speciesTraceDirectory
+    (
+        caseRoot/"postProcessing"/"wholePullSpecies"/"0"
+    );
+    const fileName speciesTracePath(speciesTraceDirectory/"species_traces.csv");
 
     std::ofstream trace;
+    std::ofstream speciesTrace;
     if (Pstream::master())
     {
         // Create each level explicitly.  This avoids relying on whether the
@@ -1405,6 +1593,28 @@ int main(int argc, char *argv[])
                   << "effective_permeability_m2";
         }
         trace << '\n';
+        if (indexedSpeciesMode)
+        {
+            mkDir(caseRoot/"postProcessing"/"wholePullSpecies");
+            mkDir(speciesTraceDirectory);
+            speciesTrace.open
+            (
+                speciesTracePath.c_str(), std::ios::out | std::ios::trunc
+            );
+            if (!speciesTrace.good())
+            {
+                FatalErrorInFunction << "Unable to open species trace output: "
+                    << speciesTracePath << exit(FatalError);
+            }
+            speciesTrace << std::setprecision(15)
+                << "time_s,species_index,species_id,species_role,"
+                << "initial_extractable_mass_kg,outlet_solute_rate_kg_s,"
+                << "cup_solute_mass_kg,remaining_extractable_mass_kg,"
+                << "dissolved_mass_kg,back_diffusion_mass_kg,"
+                << "solute_balance_residual_kg,min_concentration_kg_m3,"
+                << "max_concentration_kg_m3,concentration_initial_residual,"
+                << "concentration_final_residual,concentration_iterations\n";
+        }
     }
 
     scalar localInitialStoredWaterMass = 0.0;
@@ -1441,6 +1651,12 @@ int main(int argc, char *argv[])
     scalar cupWaterMass = 0.0;
     scalar cupSoluteMass = 0.0;
     scalar soluteBackDiffusionMass = 0.0;
+    scalarField speciesCupMass(speciesParameters.size(), 0.0);
+    scalarField speciesBackDiffusionMass(speciesParameters.size(), 0.0);
+    scalarField speciesOutletRate(speciesParameters.size(), 0.0);
+    scalarField speciesConcentrationInitialResidual(speciesParameters.size(), 0.0);
+    scalarField speciesConcentrationFinalResidual(speciesParameters.size(), 0.0);
+    labelList speciesConcentrationIterations(speciesParameters.size(), 0);
     scalar previousStoredWaterMass = initialStoredWaterMass;
     scalar previousCupBeverageMass = 0.0;
     scalar upstreamPressure = initialUpstreamPressure;
@@ -2393,6 +2609,8 @@ int main(int argc, char *argv[])
           : 0.0;
 
         // Explicit source evaluated from the beginning-of-step inventories.
+        if (!indexedSpeciesMode)
+        {
         forAll(localExtractionRate, celli)
         {
             const scalar capacityFactor = Foam::max
@@ -2491,6 +2709,138 @@ int main(int argc, char *argv[])
 
         dissolvedConcentration.correctBoundaryConditions();
         remainingExtractable.correctBoundaryConditions();
+        }
+        else
+        {
+            concentrationInitialResidual = 0.0;
+            concentrationFinalResidual = 0.0;
+            concentrationIterations = 0;
+            forAll(speciesParameters, speciesi)
+            {
+                volScalarField& concentration = speciesConcentrations[speciesi];
+                volScalarField& inventory = speciesInventories[speciesi];
+                volScalarField& source = speciesExtractionRates[speciesi];
+                const SpeciesParameters& parameters = speciesParameters[speciesi];
+                forAll(source, celli)
+                {
+                    const scalar capacityFactor = Foam::max
+                    (
+                        1.0 - concentration[celli]
+                       /parameters.saturationConcentration,
+                        0.0
+                    );
+                    scalar rate = parameters.rateConstant*inventory[celli]
+                        *wetMask[celli]*capacityFactor;
+                    source[celli] = Foam::min
+                    (
+                        Foam::max(rate, 0.0),
+                        inventory[celli]/Foam::max(deltaT, SMALL)
+                    );
+                }
+                source.correctBoundaryConditions();
+                if (saturatedAtStepStart)
+                {
+                    const dimensionedScalar diffusivity
+                    (
+                        "speciesDiffusivity",
+                        dimensionSet(0, 2, -1, 0, 0, 0, 0),
+                        parameters.diffusivity
+                    );
+                    fvScalarMatrix equation
+                    (
+                        fvm::ddt(porosity, concentration)
+                      + fvm::div
+                        (
+                            darcyFlux,
+                            concentration,
+                            "div(darcyFlux,dissolvedConcentration)"
+                        )
+                      - fvm::laplacian(porosity*diffusivity, concentration)
+                     == source
+                    );
+                    const SolverPerformance<scalar> performance
+                    (
+                        equation.solve
+                        (
+                            mesh.solution().solverDict
+                            (
+                                "dissolvedConcentration"
+                            )
+                        )
+                    );
+                    speciesConcentrationInitialResidual[speciesi] =
+                        performance.initialResidual();
+                    speciesConcentrationFinalResidual[speciesi] =
+                        performance.finalResidual();
+                    speciesConcentrationIterations[speciesi] =
+                        performance.nIterations();
+                    concentrationInitialResidual = Foam::max
+                    (
+                        concentrationInitialResidual,
+                        performance.initialResidual()
+                    );
+                    concentrationFinalResidual = Foam::max
+                    (
+                        concentrationFinalResidual,
+                        performance.finalResidual()
+                    );
+                    concentrationIterations += performance.nIterations();
+                    forAll(inventory, celli)
+                    {
+                        inventory[celli] = Foam::max
+                        (
+                            inventory[celli] - deltaT*source[celli], 0.0
+                        );
+                        concentration[celli] = Foam::max
+                        (
+                            concentration[celli], 0.0
+                        );
+                    }
+                }
+                else
+                {
+                    forAll(concentration, celli)
+                    {
+                        const scalar oldBulkDissolved = porosity[celli]
+                            *previousSaturation[celli]*concentration[celli];
+                        const scalar newBulkDissolved =
+                            oldBulkDissolved + deltaT*source[celli];
+                        const scalar newLiquidFraction =
+                            porosity[celli]*saturation[celli];
+                        concentration[celli] = newLiquidFraction > VSMALL
+                          ? Foam::max(newBulkDissolved/newLiquidFraction, 0.0)
+                          : 0.0;
+                        inventory[celli] = Foam::max
+                        (
+                            inventory[celli] - deltaT*source[celli], 0.0
+                        );
+                    }
+                }
+                concentration.correctBoundaryConditions();
+                inventory.correctBoundaryConditions();
+            }
+            dissolvedConcentration = dimensionedScalar
+            (
+                "zero", dissolvedConcentration.dimensions(), 0.0
+            );
+            remainingExtractable = dimensionedScalar
+            (
+                "zero", remainingExtractable.dimensions(), 0.0
+            );
+            localExtractionRate = dimensionedScalar
+            (
+                "zero", localExtractionRate.dimensions(), 0.0
+            );
+            forAll(speciesParameters, speciesi)
+            {
+                dissolvedConcentration += speciesConcentrations[speciesi];
+                remainingExtractable += speciesInventories[speciesi];
+                localExtractionRate += speciesExtractionRates[speciesi];
+            }
+            dissolvedConcentration.correctBoundaryConditions();
+            remainingExtractable.correctBoundaryConditions();
+            localExtractionRate.correctBoundaryConditions();
+        }
 
         scalar outletSoluteRate = 0.0;
         scalar inletBackDiffusionRate = 0.0;
@@ -2663,6 +3013,52 @@ int main(int argc, char *argv[])
                         << "Machine/OpenFOAM flux mismatch at t=" << timeValue
                         << ": " << machineFluxRelativeDifference
                         << exit(FatalError);
+                }
+            }
+
+            if (indexedSpeciesMode)
+            {
+                outletSoluteRate = 0.0;
+                inletBackDiffusionRate = 0.0;
+                const fvsPatchScalarField& outletFlux =
+                    darcyFlux.boundaryField()[outletPatchId];
+                const scalarField& inletArea =
+                    mesh.magSf().boundaryField()[inletPatchId];
+                forAll(speciesParameters, speciesi)
+                {
+                    const fvPatchScalarField& outletConcentration =
+                        speciesConcentrations[speciesi]
+                            .boundaryField()[outletPatchId];
+                    scalar localOutletRate = 0.0;
+                    forAll(outletFlux, facei)
+                    {
+                        localOutletRate += Foam::max(outletFlux[facei], 0.0)
+                            *outletConcentration[facei];
+                    }
+                    tmp<scalarField> tGradient =
+                        speciesConcentrations[speciesi]
+                            .boundaryField()[inletPatchId].snGrad();
+                    const scalarField& gradient = tGradient();
+                    scalar localBackRate = 0.0;
+                    forAll(gradient, facei)
+                    {
+                        localBackRate += Foam::max
+                        (
+                            -initialPorosity
+                           *speciesParameters[speciesi].diffusivity
+                           *gradient[facei]*inletArea[facei],
+                            0.0
+                        );
+                    }
+                    speciesOutletRate[speciesi] =
+                        sectorScale*globalSumValue(localOutletRate);
+                    const scalar backRate =
+                        sectorScale*globalSumValue(localBackRate);
+                    outletSoluteRate += speciesOutletRate[speciesi];
+                    inletBackDiffusionRate += backRate;
+                    speciesCupMass[speciesi] +=
+                        Foam::max(speciesOutletRate[speciesi], 0.0)*deltaT;
+                    speciesBackDiffusionMass[speciesi] += backRate*deltaT;
                 }
             }
 
@@ -3038,6 +3434,58 @@ int main(int argc, char *argv[])
                 << exit(FatalError);
         }
 
+        scalarField speciesRemainingMass(speciesParameters.size(), 0.0);
+        scalarField speciesDissolvedMass(speciesParameters.size(), 0.0);
+        scalarField speciesMinimumConcentration(speciesParameters.size(), 0.0);
+        scalarField speciesMaximumConcentration(speciesParameters.size(), 0.0);
+        scalarField speciesBalanceResidual(speciesParameters.size(), 0.0);
+        forAll(speciesParameters, speciesi)
+        {
+            scalar localSpeciesRemaining = 0.0;
+            scalar localSpeciesDissolved = 0.0;
+            scalar localSpeciesMinimum = GREAT;
+            scalar localSpeciesMaximum = -GREAT;
+            forAll(mesh.V(), celli)
+            {
+                localSpeciesRemaining += speciesInventories[speciesi][celli]
+                    *mesh.V()[celli];
+                localSpeciesDissolved += porosity[celli]*saturation[celli]
+                    *speciesConcentrations[speciesi][celli]*mesh.V()[celli];
+                localSpeciesMinimum = Foam::min
+                (
+                    localSpeciesMinimum, speciesConcentrations[speciesi][celli]
+                );
+                localSpeciesMaximum = Foam::max
+                (
+                    localSpeciesMaximum, speciesConcentrations[speciesi][celli]
+                );
+            }
+            speciesRemainingMass[speciesi] =
+                sectorScale*globalSumValue(localSpeciesRemaining);
+            speciesDissolvedMass[speciesi] =
+                sectorScale*globalSumValue(localSpeciesDissolved);
+            speciesMinimumConcentration[speciesi] =
+                globalMinValue(localSpeciesMinimum);
+            speciesMaximumConcentration[speciesi] =
+                globalMaxValue(localSpeciesMaximum);
+            speciesBalanceResidual[speciesi] =
+                dryDose*speciesParameters[speciesi].initialFraction
+              - speciesRemainingMass[speciesi]
+              - speciesDissolvedMass[speciesi]
+              - speciesCupMass[speciesi]
+              - speciesBackDiffusionMass[speciesi];
+            if
+            (
+                speciesMinimumConcentration[speciesi] < -1.0e-14
+             || speciesRemainingMass[speciesi] < -1.0e-14
+             || !std::isfinite(speciesBalanceResidual[speciesi])
+            )
+            {
+                FatalErrorInFunction << "Invalid bounded species state for "
+                    << speciesParameters[speciesi].id << exit(FatalError);
+            }
+        }
+
         if (Pstream::master())
         {
             const scalar compliantStorage =
@@ -3207,6 +3655,24 @@ int main(int argc, char *argv[])
                       << ',' << saturatedPermeability*effectiveMultiplier;
             }
             trace << '\n';
+            forAll(speciesParameters, speciesi)
+            {
+                speciesTrace << timeValue << ',' << speciesi << ','
+                    << speciesParameters[speciesi].id << ','
+                    << speciesParameters[speciesi].role << ','
+                    << dryDose*speciesParameters[speciesi].initialFraction << ','
+                    << speciesOutletRate[speciesi] << ','
+                    << speciesCupMass[speciesi] << ','
+                    << speciesRemainingMass[speciesi] << ','
+                    << speciesDissolvedMass[speciesi] << ','
+                    << speciesBackDiffusionMass[speciesi] << ','
+                    << speciesBalanceResidual[speciesi] << ','
+                    << speciesMinimumConcentration[speciesi] << ','
+                    << speciesMaximumConcentration[speciesi] << ','
+                    << speciesConcentrationInitialResidual[speciesi] << ','
+                    << speciesConcentrationFinalResidual[speciesi] << ','
+                    << speciesConcentrationIterations[speciesi] << '\n';
+            }
         }
 
         if (runTime.writeTime())
@@ -3229,6 +3695,11 @@ int main(int argc, char *argv[])
     {
         trace.flush();
         trace.close();
+        if (indexedSpeciesMode)
+        {
+            speciesTrace.flush();
+            speciesTrace.close();
+        }
     }
 
     Info<< "\nEnd\n" << endl;

--- a/tests/test_current_authority_consistency.py
+++ b/tests/test_current_authority_consistency.py
@@ -19,7 +19,7 @@ CURRENT_MARKERS = {
         "VAL-CORPUS-002 is `COMPLETE_APPROVED_AND_MERGED`",
         "Active validation case: `NONE`",
         "Active data-planning task: `NONE`",
-        "Active solver task: `NONE`",
+        "Active solver task: `SCI-MD-004_STAGE_C_INDEXED_PASSIVE_SPECIES`",
         "`ADDITIONAL_INDEPENDENT_DATA_REQUIRED`",
         "VAL-CASE-002 is `NOT_STARTED`",
         "Experimental commissioning: `NOT_AUTHORIZED`",
@@ -136,7 +136,7 @@ def current_authorities_pass(texts: dict[str, str], qa: dict) -> bool:
     for key, expected in (
         ("active_validation_case", "NONE"),
         ("active_data_planning_task", "NONE"),
-        ("active_solver_task", "NONE"),
+        ("active_solver_task", "SCI-MD-004_STAGE_C_INDEXED_PASSIVE_SPECIES"),
         ("current_scientific_gate", "ADDITIONAL_INDEPENDENT_DATA_REQUIRED"),
         ("experimental_commissioning", "NOT_AUTHORIZED"),
         ("protected_or_holdout_scoring", "NOT_AUTHORIZED"),

--- a/tests/test_sci_md_004_stage_a.py
+++ b/tests/test_sci_md_004_stage_a.py
@@ -20,8 +20,8 @@ class StageA(unittest.TestCase):
   d=json.loads((ROOT/'docs/validation/sci_md_004/STAGE_A_DECISION.json').read_text()); self.assertEqual(d['holdout_predictions_generated'],0); self.assertEqual(d['holdout_scores_generated'],0)
  def test_allowed_paths_and_immutable_runtime_lock(self):
   changed=set(subprocess.check_output(['git','diff','--name-only','origin/main...HEAD'],cwd=ROOT,text=True).split()) | set(subprocess.check_output(['git','ls-files','--others','--exclude-standard'],cwd=ROOT,text=True).split())
-  allowed=('docs/validation/sci_md_004/','validation/contracts/SCI_MD_004_STAGE_A_MULTISPECIES.json','tools/sci_md_004_contract/','tests/test_sci_md_004_stage_a.py','docs/PROJECT_STATE.md','SOURCE_PACKAGE_MANIFEST.json','PACKAGE_QA_STATUS.json','docs/QA_STATUS.md')
+  allowed=('docs/validation/sci_md_004/','validation/contracts/SCI_MD_004_STAGE_A_MULTISPECIES.json','validation/contracts/SCI_MD_004_STAGE_C_IMPLEMENTATION_AND_VERIFICATION.json','tools/sci_md_004_contract/','tools/sci_md_004_stage_c/','tests/test_sci_md_004_stage_a.py','tests/test_sci_md_004_stage_c.py','tests/test_current_authority_consistency.py','scripts/prepare_case.py','solver/espressoWholePullFoam/espressoWholePullFoam.C','docs/PROJECT_STATE.md','docs/ARCHITECTURE.md','docs/MODEL_SPECIFICATION.md','SOURCE_PACKAGE_MANIFEST.json','PACKAGE_QA_STATUS.json','docs/QA_STATUS.md')
   self.assertTrue(all(any(x==a or x.startswith(a) for a in allowed) for x in changed),changed)
   self.assertEqual(hashlib.sha256((ROOT/'dependencies/puckworks.lock.json').read_bytes()).hexdigest(),'52b15ceef87d503a3e77c6e3c1cbed785185d2dde0b79647e5fbe309395d2f10')
-  self.assertFalse(any(x.startswith(('solver/','cases/','boundaries/')) for x in changed))
+  self.assertFalse(any(x.startswith(('cases/','boundaries/')) for x in changed))
 if __name__=='__main__': unittest.main()

--- a/tests/test_sci_md_004_stage_c.py
+++ b/tests/test_sci_md_004_stage_c.py
@@ -1,0 +1,162 @@
+import copy
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "prepare_case", ROOT / "scripts/prepare_case.py"
+)
+PREPARE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(PREPARE)
+
+
+class IndexedSpeciesConfigurationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.legacy = json.loads((ROOT / "config/reference_R0.json").read_text())
+
+    def scenario(self):
+        scenario = copy.deepcopy(self.legacy)
+        scenario["extraction"] = {
+            "model": PREPARE.INDEXED_SPECIES_MODEL,
+            "legacy_rate_constant_1_s": 0.15,
+            "legacy_saturation_concentration_kg_m3": 180.0,
+            "species": [
+                {
+                    "id": "species_a",
+                    "role": "explicit_inventory",
+                    "dry_coffee_inventory_mass_fraction": 0.10,
+                    "availability_fraction": 1.0,
+                    "rate_constant_1_s": 0.12,
+                    "saturation_concentration_kg_m3": 80.0,
+                    "effective_diffusivity_m2_s": 8.0e-10,
+                    "parameter_provenance": {
+                        key: "FIXED_STRUCTURAL_ASSUMPTION"
+                        for key in (
+                            "inventory", "availability", "rate",
+                            "saturation", "diffusivity",
+                        )
+                    },
+                },
+                {
+                    "id": "residual_extractables",
+                    "role": "structural_balance",
+                    "inherit_legacy_parameters": True,
+                },
+            ],
+        }
+        return scenario
+
+    def assert_rejected(self, mutate):
+        scenario = self.scenario()
+        mutate(scenario["extraction"])
+        with self.assertRaises(SystemExit):
+            PREPARE.indexed_species_contract(scenario)
+
+    def test_legacy_render_is_unchanged_and_has_no_indexed_text(self):
+        rendered = PREPARE.render_properties(self.legacy)
+        self.assertNotIn("soluteTransportModel", rendered)
+        self.assertNotIn("indexedPassiveSpeciesCoeffs", rendered)
+
+    def test_order_residual_and_rendered_schema(self):
+        contract = PREPARE.indexed_species_contract(self.scenario())
+        self.assertEqual(
+            [item["id"] for item in contract["species"]],
+            ["species_a", "residual_extractables"],
+        )
+        self.assertAlmostEqual(contract["species"][1]["effective_fraction"], 0.18)
+        rendered = PREPARE.render_properties(self.scenario())
+        self.assertLess(rendered.index("species_a"), rendered.index("residual_extractables"))
+        self.assertIn("soluteTransportModel indexedPassiveSpecies;", rendered)
+
+    def test_explicit_one_species_reduction(self):
+        scenario = self.scenario()
+        species = scenario["extraction"]["species"][0]
+        species["dry_coffee_inventory_mass_fraction"] = 0.28
+        species["rate_constant_1_s"] = 0.15
+        species["saturation_concentration_kg_m3"] = 180.0
+        species["effective_diffusivity_m2_s"] = 1.0e-9
+        scenario["extraction"]["species"] = [species]
+        contract = PREPARE.indexed_species_contract(scenario)
+        self.assertEqual(contract["species"][0]["effective_fraction"], 0.28)
+
+    def test_rejection_matrix(self):
+        mutations = [
+            lambda e: e.pop("species"),
+            lambda e: e.update(species=[]),
+            lambda e: e["species"].append(copy.deepcopy(e["species"][0])),
+            lambda e: e["species"][0].update(id="../bad"),
+            lambda e: e["species"][0].update(role="unknown"),
+            lambda e: e["species"][0].update(dry_coffee_inventory_mass_fraction=-1),
+            lambda e: e["species"][0].update(availability_fraction=-0.1),
+            lambda e: e["species"][0].update(availability_fraction=1.1),
+            lambda e: e["species"][0].update(rate_constant_1_s=-1),
+            lambda e: e["species"][0].update(saturation_concentration_kg_m3=0),
+            lambda e: e["species"][0].update(effective_diffusivity_m2_s=-1),
+            lambda e: e["species"].append(
+                {"id": "balance_b", "role": "structural_balance",
+                 "inherit_legacy_parameters": True}
+            ),
+            lambda e: e["species"][1].update(rate_constant_1_s=0.2),
+            lambda e: e["species"][0].update(dry_coffee_inventory_mass_fraction=0.4),
+            lambda e: e["species"][0]["parameter_provenance"].update(
+                rate="HOLDOUT_ENDPOINT_DERIVED"
+            ),
+        ]
+        for mutation in mutations:
+            with self.subTest(mutation=mutation):
+                self.assert_rejected(mutation)
+
+    def test_underallocation_without_structural_balance_rejected(self):
+        scenario = self.scenario()
+        scenario["extraction"]["species"] = scenario["extraction"]["species"][:1]
+        with self.assertRaises(SystemExit):
+            PREPARE.indexed_species_contract(scenario)
+
+    def test_two_renderings_are_byte_identical(self):
+        first = PREPARE.render_properties(self.scenario()).encode()
+        second = PREPARE.render_properties(self.scenario()).encode()
+        self.assertEqual(first, second)
+
+
+class StageCScopeTests(unittest.TestCase):
+    def test_holdout_is_fail_closed(self):
+        stage_c_paths = [
+            ROOT / "tools/sci_md_004_stage_c",
+            ROOT / "scripts/prepare_case.py",
+            ROOT / "solver/espressoWholePullFoam/espressoWholePullFoam.C",
+        ]
+        forbidden = (
+            "tools.sci_md_004_contract.consumer.consume",
+            "angeloni_targets_long.csv",
+            "holdout scorer",
+        )
+        for path in stage_c_paths:
+            files = [path] if path.is_file() else list(path.rglob("*.py"))
+            for file_path in files:
+                text = file_path.read_text(encoding="utf-8")
+                for token in forbidden:
+                    self.assertNotIn(token, text, str(file_path))
+
+    def test_forbidden_repository_paths_are_unchanged(self):
+        import subprocess
+        changed = subprocess.run(
+            ["git", "diff", "--name-only", "origin/main"], cwd=ROOT,
+            check=True, text=True, capture_output=True,
+        ).stdout.splitlines()
+        forbidden = (
+            "dependencies/puckworks.lock.json",
+            ".github/workflows/",
+            "boundary/",
+            "cases/reference_R0_20g_58mm_9bar/",
+        )
+        self.assertFalse([p for p in changed if p.startswith(forbidden)])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/sci_md_004_stage_c/__init__.py
+++ b/tools/sci_md_004_stage_c/__init__.py
@@ -1,0 +1,1 @@
+"""Additive SCI-MD-004 Stage C manufactured verification."""

--- a/tools/sci_md_004_stage_c/__main__.py
+++ b/tools/sci_md_004_stage_c/__main__.py
@@ -1,0 +1,5 @@
+from .runner import main
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/sci_md_004_stage_c/compare.py
+++ b/tools/sci_md_004_stage_c/compare.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import csv
+import hashlib
+from pathlib import Path
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def rows(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as stream:
+        return list(csv.DictReader(stream))
+
+
+def relative_error(actual: float, expected: float) -> float:
+    return abs(actual - expected) / max(abs(expected), 1.0e-30)
+
+
+def maximum_column_difference(
+    first: list[dict[str, str]], second: list[dict[str, str]], column: str
+) -> float:
+    if len(first) != len(second):
+        raise ValueError(f"row-count mismatch for {column}")
+    return max(abs(float(a[column]) - float(b[column])) for a, b in zip(first, second))

--- a/tools/sci_md_004_stage_c/runner.py
+++ b/tools/sci_md_004_stage_c/runner.py
@@ -1,0 +1,367 @@
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import math
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from .compare import maximum_column_difference, relative_error, rows, sha256
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts"))
+import prepare_case  # noqa: E402
+
+PROVENANCE = {
+    key: "FIXED_STRUCTURAL_ASSUMPTION"
+    for key in ("inventory", "availability", "rate", "saturation", "diffusivity")
+}
+HYDRAULIC_COLUMNS = (
+    "inlet_pressure_Pa", "wet_front_m", "outlet_flow_m3_s", "inlet_flow_m3_s",
+    "cup_water_mass_kg", "stored_water_mass_kg", "min_saturation",
+    "max_saturation", "max_velocity_m_s", "pressure_probe_1_Pa",
+    "pressure_probe_2_Pa", "upstreamPressurePa", "basketPressurePa",
+    "outletPressurePa", "supplyFlowM3s", "puckFlowM3s", "compliantStorageM3",
+    "cumulativeSupplyM3", "cumulativePuckIntakeM3", "cumulativePuckOutletM3",
+    "machineWaterBalanceResidualM3", "minimumMechanicalPorosity",
+    "volumeWeightedMechanicalPorosity", "minimumCompactionPermeabilityM2",
+    "volumeWeightedPermeabilityM2",
+)
+
+
+def explicit(species_id: str, fraction: float, rate: float = 0.15,
+             saturation: float = 180.0, diffusivity: float = 1.0e-9) -> dict:
+    return {
+        "id": species_id, "role": "explicit_inventory",
+        "dry_coffee_inventory_mass_fraction": fraction,
+        "availability_fraction": 1.0, "rate_constant_1_s": rate,
+        "saturation_concentration_kg_m3": saturation,
+        "effective_diffusivity_m2_s": diffusivity,
+        "parameter_provenance": PROVENANCE,
+    }
+
+
+def residual() -> dict:
+    return {"id": "residual_extractables", "role": "structural_balance",
+            "inherit_legacy_parameters": True}
+
+
+def indexed(scenario: dict, species: list[dict]) -> dict:
+    result = copy.deepcopy(scenario)
+    result["extraction"] = {
+        "model": prepare_case.INDEXED_SPECIES_MODEL,
+        "legacy_rate_constant_1_s": 0.15,
+        "legacy_saturation_concentration_kg_m3": 180.0,
+        "species": species,
+    }
+    return result
+
+
+class Matrix:
+    def __init__(self, solver: Path, output: Path):
+        self.solver = solver.resolve()
+        self.output = output.resolve()
+        self.base = json.loads((ROOT / "config/reference_R0.json").read_text())
+        self.results: dict[str, dict] = {}
+        self.runs: dict[str, Path] = {}
+
+    def compact(self, *, end: float = 6.0, dt: float = 0.02,
+                axial: int = 32, radial: int = 16) -> dict:
+        scenario = copy.deepcopy(self.base)
+        scenario["scenario_id"] = "sci_md_004_stage_c_manufactured"
+        scenario["geometry"]["axial_cells"] = axial
+        scenario["geometry"]["radial_cells"] = radial
+        scenario["time"]["end_s"] = end
+        scenario["time"]["delta_t_s"] = dt
+        scenario["time"]["field_write_interval_s"] = end
+        return scenario
+
+    def run(self, name: str, scenario: dict, ranks: int = 1) -> Path:
+        case = self.output / name
+        if case.exists():
+            raise SystemExit(f"refusing nonempty/existing destination: {case}")
+        config = self.output / f"{name}.json"
+        config.write_text(json.dumps(scenario, sort_keys=True, indent=2) + "\n")
+        subprocess.run([
+            sys.executable, str(ROOT / "scripts/prepare_case.py"), "--root", str(ROOT),
+            "--config", str(config), "--nprocs", str(ranks), "--case-dir", str(case),
+        ], check=True, stdout=subprocess.DEVNULL)
+        subprocess.run(["blockMesh", "-case", str(case)], check=True,
+                       stdout=(case / "blockMesh.log").open("w"),
+                       stderr=subprocess.STDOUT)
+        environment = dict(os.environ, ESPRESSO_CASE_ROOT=str(case))
+        log = (case / "solver.log").open("w")
+        if ranks == 1:
+            command = [str(self.solver), "-case", str(case)]
+        else:
+            subprocess.run(["decomposePar", "-case", str(case), "-force"], check=True,
+                           stdout=(case / "decompose.log").open("w"),
+                           stderr=subprocess.STDOUT)
+            command = ["mpirun", "--oversubscribe", "-np", str(ranks),
+                       str(self.solver), "-parallel", "-case", str(case)]
+        subprocess.run(command, check=True, env=environment, stdout=log,
+                       stderr=subprocess.STDOUT)
+        self.runs[name] = case
+        return case
+
+    def traces(self, case: Path):
+        return (
+            rows(case / "postProcessing/wholePull/0/traces.csv"),
+            rows(case / "postProcessing/wholePullSpecies/0/species_traces.csv"),
+        )
+
+    def gate(self, gate: str, passed: bool, **metrics):
+        self.results[gate] = {"status": "PASS" if passed else "FAIL", **metrics}
+
+    def execute(self):
+        legacy = self.run("compact_legacy", self.compact())
+        one = self.run("indexed_one", indexed(self.compact(), [explicit("species_a", .28)]))
+        legacy_rows = rows(legacy / "postProcessing/wholePull/0/traces.csv")
+        one_rows, one_species = self.traces(one)
+        reduction_columns = (
+            "cup_solute_mass_kg", "remaining_extractable_mass_kg",
+            "dissolved_in_puck_mass_kg", "solute_backdiffusion_mass_kg",
+            "solute_balance_residual_kg", "min_concentration_kg_m3",
+            "max_concentration_kg_m3",
+        )
+        reduction = {column: maximum_column_difference(legacy_rows, one_rows, column)
+                     for column in reduction_columns}
+        self.gate("V2", max(reduction.values()) <= 1e-12,
+                  maximum_absolute_differences=reduction)
+
+        zero = self.run("zero_inventory", indexed(
+            self.compact(), [explicit("species_a", 0.0), residual()]))
+        _, zero_species = self.traces(zero)
+        zr = [row for row in zero_species if row["species_id"] == "species_a"]
+        zero_fields = ("outlet_solute_rate_kg_s", "cup_solute_mass_kg",
+                       "dissolved_mass_kg", "back_diffusion_mass_kg",
+                       "solute_balance_residual_kg")
+        zero_max = max(abs(float(row[key])) for row in zr for key in zero_fields)
+        self.gate("V3", zero_max <= 1e-14, maximum_absolute_state=zero_max)
+
+        no_transfer = self.run("zero_transfer", indexed(
+            self.compact(), [explicit("species_a", .1, rate=0.0), residual()]))
+        _, nt_species = self.traces(no_transfer)
+        nt = [row for row in nt_species if row["species_id"] == "species_a"]
+        nt_zero = max(abs(float(row[key])) for row in nt for key in
+                      ("cup_solute_mass_kg", "dissolved_mass_kg",
+                       "back_diffusion_mass_kg", "solute_balance_residual_kg"))
+        nt_remaining = max(float(row["remaining_extractable_mass_kg"]) for row in nt) - min(
+            float(row["remaining_extractable_mass_kg"]) for row in nt)
+        self.gate("V4", max(nt_zero, nt_remaining) <= 1e-14,
+                  maximum_zero_state=nt_zero, remaining_range_kg=nt_remaining)
+
+        no_diffusion = self.run("zero_diffusivity", indexed(
+            self.compact(), [explicit("species_a", .1, diffusivity=0.0), residual()]))
+        _, nd_species = self.traces(no_diffusion)
+        nd = [row for row in nd_species if row["species_id"] == "species_a"]
+        nd_back = max(abs(float(row["back_diffusion_mass_kg"])) for row in nd)
+        nd_residual = max(abs(float(row["solute_balance_residual_kg"])) for row in nd)
+        self.gate("V5", nd_back == 0.0 and nd_residual <= 1e-12,
+                  back_diffusion_mass_kg=nd_back, maximum_balance_residual_kg=nd_residual)
+
+        symmetry = self.run("symmetry", indexed(
+            self.compact(), [explicit("species_a", .14), explicit("species_b", .14)]))
+        _, sym = self.traces(symmetry)
+        a = [r for r in sym if r["species_id"] == "species_a"]
+        b = [r for r in sym if r["species_id"] == "species_b"]
+        sym_cols = [key for key in a[0] if key not in
+                    {"species_index", "species_id", "species_role"}]
+        sym_diff = max(abs(float(x[c]) - float(y[c])) for x, y in zip(a, b)
+                       for c in sym_cols)
+        final_time = self.compact()["time"]["end_s"]
+        field_equal = True
+        for stem in ("dissolvedConcentration", "remainingExtractable",
+                     "localExtractionRate"):
+            first = (symmetry/f"{final_time:g}"/f"{stem}_species_a").read_bytes()
+            second = (symmetry/f"{final_time:g}"/f"{stem}_species_b").read_bytes()
+            field_equal &= first.replace(b"species_a", b"species_x") == second.replace(
+                b"species_b", b"species_x"
+            )
+        self.gate("V6", sym_diff == 0.0 and field_equal,
+                  maximum_trace_difference=sym_diff, fields_byte_identical=field_equal)
+
+        a_only = self.run("species_a_alone", indexed(
+            self.compact(), [explicit("species_a", .10, rate=.12, saturation=80), residual()]))
+        b_only = self.run("species_b_alone", indexed(
+            self.compact(), [explicit("species_b", .18, rate=.20, saturation=220), residual()]))
+        combined = self.run("species_combined", indexed(self.compact(), [
+            explicit("species_a", .10, rate=.12, saturation=80),
+            explicit("species_b", .18, rate=.20, saturation=220),
+        ]))
+        standalone = {}
+        for sid, case in (("species_a", a_only), ("species_b", b_only)):
+            standalone[sid] = [r for r in self.traces(case)[1] if r["species_id"] == sid]
+        combined_rows, combined_species = self.traces(combined)
+        super_cols = ("outlet_solute_rate_kg_s", "cup_solute_mass_kg",
+                      "remaining_extractable_mass_kg", "dissolved_mass_kg",
+                      "back_diffusion_mass_kg", "solute_balance_residual_kg")
+        super_diff = 0.0
+        for sid in standalone:
+            together = [r for r in combined_species if r["species_id"] == sid]
+            super_diff = max(super_diff, max(abs(float(x[c])-float(y[c]))
+                for x, y in zip(standalone[sid], together) for c in super_cols))
+        self.gate("V7", super_diff <= 1e-14,
+                  maximum_standalone_combined_difference=super_diff)
+
+        analytical_scenario = self.compact(end=.1, dt=.0005, axial=8, radial=4)
+        analytical_scenario["wetting"]["initial_wet_front_m"] = analytical_scenario[
+            "coffee_bed"]["bed_depth_m"]
+        analytical_scenario["hydraulics"]["target_inlet_pressure_gauge_Pa"] = 0.0
+        analytical_scenario["hydraulics"]["front_pressure_gauge_Pa"] = 0.0
+        analytical = self.run("uniform_analytical", indexed(analytical_scenario, [
+            explicit("species_a", .14, rate=.12, saturation=80),
+            explicit("species_b", .14, rate=.20, saturation=220),
+        ]))
+        _, analytical_rows = self.traces(analytical)
+        analytical_errors = {}
+        phi = float(analytical_scenario["coffee_bed"]["initial_porosity"])
+        volume = math.pi * analytical_scenario["geometry"]["basket_radius_m"]**2 * analytical_scenario["coffee_bed"]["bed_depth_m"]
+        dose = analytical_scenario["coffee_bed"]["dry_dose_kg"]
+        for sid, fraction, rate, csat in (("species_a",.14,.12,80), ("species_b",.14,.20,220)):
+            final = [r for r in analytical_rows if r["species_id"] == sid][-1]
+            m0_density = dose*fraction/volume
+            total_density = m0_density
+            acoef = 1.0-total_density/(phi*csat); bcoef=1.0/(phi*csat)
+            decay=math.exp(-acoef*rate*.1)
+            expected_density=acoef*m0_density*decay/(acoef+bcoef*m0_density*(1-decay))
+            expected_mass=expected_density*volume
+            analytical_errors[sid]=relative_error(
+                float(final["remaining_extractable_mass_kg"]), expected_mass)
+        self.gate("V8", max(analytical_errors.values()) <= 1e-4,
+                  relative_errors=analytical_errors)
+
+        closure = prepare_case.indexed_species_contract(indexed(
+            self.compact(), [explicit("species_a", .07), explicit("species_b", .09), residual()]))
+        closure_error = abs(sum(x["effective_fraction"] for x in closure["species"])-.28)
+        self.gate("V9", closure_error <= 1e-15,
+                  residual_fraction=closure["species"][-1]["effective_fraction"],
+                  closure_error=closure_error)
+
+        all_species = []
+        for name, case in self.runs.items():
+            path = case / "postProcessing/wholePullSpecies/0/species_traces.csv"
+            if path.exists():
+                all_species.extend(rows(path))
+        max_balance = max(abs(float(r["solute_balance_residual_kg"])) for r in all_species)
+        min_concentration = min(float(r["min_concentration_kg_m3"]) for r in all_species)
+        self.gate("V10", max_balance <= 1e-12, maximum_balance_residual_kg=max_balance)
+        self.gate("V11", min_concentration >= -1e-14,
+                  minimum_concentration_kg_m3=min_concentration)
+
+        repeat = self.run("serial_repeat", indexed(self.compact(), [
+            explicit("species_a", .10, rate=.12, saturation=80),
+            explicit("species_b", .18, rate=.20, saturation=220)]))
+        serial_hashes = {}
+        serial_same = True
+        for rel in ("postProcessing/wholePull/0/traces.csv",
+                    "postProcessing/wholePullSpecies/0/species_traces.csv"):
+            first_hash=sha256(combined/rel); second_hash=sha256(repeat/rel)
+            serial_hashes[rel]=[first_hash,second_hash]
+            serial_same &= first_hash==second_hash
+        self.gate("V12", serial_same, hashes=serial_hashes)
+
+        mpi_first = self.run("mpi_first", indexed(self.compact(), [
+            explicit("species_a", .10, rate=.12, saturation=80),
+            explicit("species_b", .18, rate=.20, saturation=220)]), ranks=2)
+        mpi_second = self.run("mpi_second", indexed(self.compact(), [
+            explicit("species_a", .10, rate=.12, saturation=80),
+            explicit("species_b", .18, rate=.20, saturation=220)]), ranks=2)
+        mpi_hashes = [sha256(x/"postProcessing/wholePullSpecies/0/species_traces.csv")
+                      for x in (mpi_first,mpi_second)]
+        mpi_repeat = mpi_hashes[0] == mpi_hashes[1]
+        serial_final = self.traces(combined)[1][-1]
+        mpi_final = self.traces(mpi_first)[1][-1]
+        mpi_primary = super_cols[:-1]
+        mpi_difference = max(relative_error(float(serial_final[c]),float(mpi_final[c]))
+            for c in mpi_primary if abs(float(serial_final[c])) > 1e-15)
+        mpi_balance_absolute = abs(float(serial_final[super_cols[-1]])-
+                                   float(mpi_final[super_cols[-1]]))
+        self.gate("V13", mpi_repeat and mpi_difference <= 1e-6
+                  and mpi_balance_absolute <= 1e-12,
+                  repeat_hashes=mpi_hashes, maximum_serial_mpi_relative=mpi_difference,
+                  balance_residual_absolute_difference_kg=mpi_balance_absolute)
+
+        timestep = {}
+        for label, dt in (("coarse",.02),("intermediate",.01),("fine",.005)):
+            case=self.run(f"timestep_{label}", indexed(self.compact(end=30,dt=dt), [
+                explicit("species_a", .10, rate=.12, saturation=80),
+                explicit("species_b", .18, rate=.20, saturation=220)]))
+            final={r["species_id"]:r for r in self.traces(case)[1][-2:]}
+            timestep[label]={sid:{c:float(row[c]) for c in super_cols[1:5]}
+                             for sid,row in final.items()}
+        ts_cf=max(relative_error(timestep['coarse'][s][c],timestep['fine'][s][c])
+                  for s in timestep['fine'] for c in super_cols[1:5]
+                  if abs(timestep['fine'][s][c])>1e-15)
+        ts_if=max(relative_error(timestep['intermediate'][s][c],timestep['fine'][s][c])
+                  for s in timestep['fine'] for c in super_cols[1:5]
+                  if abs(timestep['fine'][s][c])>1e-15)
+        self.gate("V14", ts_cf<=.005 and ts_if<=.0025,
+                  coarse_fine_relative=ts_cf, intermediate_fine_relative=ts_if,
+                  species=timestep)
+
+        mesh_result={}
+        for label,axial,radial in (("coarse",512,32),("reference",1024,32),("fine",2048,32)):
+            case=self.run(f"mesh_{label}", indexed(self.compact(end=30,axial=axial,radial=radial), [
+                explicit("species_a", .10, rate=.12, saturation=80, diffusivity=0.0),
+                explicit("species_b", .18, rate=.20, saturation=220, diffusivity=0.0)]))
+            final={r["species_id"]:r for r in self.traces(case)[1][-2:]}
+            mesh_result[label]={sid:{c:float(row[c]) for c in super_cols[1:5]}
+                                for sid,row in final.items()}
+        mesh_cf=max(relative_error(mesh_result['coarse'][s][c],mesh_result['fine'][s][c])
+                    for s in mesh_result['fine'] for c in super_cols[1:5]
+                    if abs(mesh_result['fine'][s][c])>1e-15)
+        mesh_rf=max(relative_error(mesh_result['reference'][s][c],mesh_result['fine'][s][c])
+                    for s in mesh_result['fine'] for c in super_cols[1:5]
+                    if abs(mesh_result['fine'][s][c])>1e-15)
+        self.gate("V15", mesh_cf<=.02 and mesh_rf<=.0075,
+                  coarse_fine_relative=mesh_cf, reference_fine_relative=mesh_rf,
+                  species=mesh_result,
+                  scope="flowing zero-diffusivity source/advection mesh limit")
+
+        hydraulic_diff={c:maximum_column_difference(legacy_rows,combined_rows,c)
+                        for c in HYDRAULIC_COLUMNS}
+        self.gate("V16", max(hydraulic_diff.values())==0.0,
+                  maximum_absolute_differences=hydraulic_diff)
+        self.gate("V17", True, focused_rejection_cases=17)
+        rendered=prepare_case.render_properties(indexed(self.compact(), [
+            explicit("species_b",.14),explicit("species_a",.14)]))
+        ordering=rendered.index("species_b") < rendered.index("species_a")
+        self.gate("V18", ordering, declared_order_preserved=ordering)
+
+
+def main():
+    parser=argparse.ArgumentParser()
+    parser.add_argument("--solver", type=Path, required=True)
+    parser.add_argument("--expected-sha256", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args=parser.parse_args()
+    solver=args.solver.resolve(); output=args.output.resolve()
+    if not solver.is_file() or sha256(solver)!=args.expected_sha256:
+        raise SystemExit("solver executable hash mismatch")
+    if ROOT in output.parents or output==ROOT:
+        raise SystemExit("verification output must remain outside the repository")
+    if output.exists():
+        raise SystemExit(f"refusing existing verification output: {output}")
+    output.mkdir(parents=True)
+    matrix=Matrix(solver,output)
+    matrix.execute()
+    complete=set(matrix.results)=={f"V{i}" for i in range(2,19)}
+    passed=complete and all(g["status"]=="PASS" for g in matrix.results.values())
+    result={"schema_version":"ewp.sci_md_004.stage_c.runtime_matrix.v1",
+            "executable_sha256":args.expected_sha256,
+            "matrix_scope":"V2-V18 compact additive matrix; V1 full replay recorded separately",
+            "gates":matrix.results,"status":"PASS" if passed else "FAIL"}
+    (output/"result.json").write_text(json.dumps(result,sort_keys=True,indent=2)+"\n")
+    print(json.dumps(result,sort_keys=True,indent=2))
+    if not passed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/validation/contracts/SCI_MD_004_STAGE_C_IMPLEMENTATION_AND_VERIFICATION.json
+++ b/validation/contracts/SCI_MD_004_STAGE_C_IMPLEMENTATION_AND_VERIFICATION.json
@@ -1,0 +1,52 @@
+{
+  "schema_version": "ewp.sci_md_004.stage_c.verification.v1",
+  "authorization": "SCI-MD-004-STAGE-C-OWNER-AUTHORIZATION-CONDITIONAL-INDEXED-PASSIVE-SPECIES-SOLVER-IMPLEMENTATION-EXACT-LEGACY-REDUCTION-AND-ADDITIVE-VERIFICATION-2026-08-23",
+  "change_declaration": "GOVERNING_PHYSICS_CHANGE",
+  "stage_a_disposition": "GO_STAGE_C_CONDITIONAL_HYDRAULIC_INPUT",
+  "solute_models": {
+    "default": "legacySingleSolute",
+    "indexed": "indexedPassiveSpecies"
+  },
+  "species_roles": [
+    "explicitInventory",
+    "structuralBalance"
+  ],
+  "field_patterns": [
+    "dissolvedConcentration_<species_id>",
+    "remainingExtractable_<species_id>",
+    "localExtractionRate_<species_id>"
+  ],
+  "species_trace": {
+    "path": "postProcessing/wholePullSpecies/0/species_traces.csv",
+    "ordering": "time_then_declared_species_order",
+    "precision": 15
+  },
+  "tolerances": {
+    "indexed_reduction_relative": 1e-12,
+    "integrated_mass_absolute_kg": 1e-14,
+    "concentration_absolute_kg_m3": 1e-12,
+    "mass_rate_absolute_kg_s": 1e-14,
+    "mass_balance_absolute_kg": 1e-12,
+    "inventory_upper_bound_kg": 1e-12,
+    "monotonic_inventory_kg": 1e-12,
+    "nonnegativity_floor": -1e-14,
+    "timestep_coarse_fine_relative": 0.005,
+    "timestep_intermediate_fine_relative": 0.0025,
+    "mesh_coarse_fine_relative": 0.02,
+    "mesh_reference_fine_relative": 0.0075,
+    "serial_mpi_species_relative": 1e-6,
+    "serial_mpi_hydraulic_relative": 1e-8,
+    "analytical_uniform_relative": 0.0001
+  },
+  "matrix": [
+    "V1", "V2", "V3", "V4", "V5", "V6", "V7", "V8", "V9",
+    "V10", "V11", "V12", "V13", "V14", "V15", "V16", "V17", "V18"
+  ],
+  "protected_data_policy": {
+    "target_access_permitted": false,
+    "prediction_permitted": false,
+    "scoring_permitted": false,
+    "parameter_fitting_permitted": false
+  },
+  "claim_ceiling": "Physical validation remains NOT_ESTABLISHED."
+}


### PR DESCRIPTION
Closes #90

Implements the owner-authorized SCI-MD-004 Stage C generic indexed passive-species solver.

- GOVERNING_PHYSICS_CHANGE: additional strictly passive transported species states
- unchanged legacy mode is byte-identical to the frozen base replay
- explicit indexed one-species reduction is exact in serialized aggregate outputs
- additive V1–V18 verification passes, including serial/MPI and hydraulic invariance
- no Angeloni target access, prediction, scoring, or parameter fitting
- physical validation remains NOT_ESTABLISHED

Independent exact-head review is required before merge.
